### PR TITLE
Faster loading change

### DIFF
--- a/Paco-Server/src/com/google/sampling/experiential/datastore/JsonConverter.java
+++ b/Paco-Server/src/com/google/sampling/experiential/datastore/JsonConverter.java
@@ -74,7 +74,7 @@ public class JsonConverter {
   private static ExperimentDAOCore experimentDAOCoreFromExperimentDAO(ExperimentDAO experiment) {
     return new ExperimentDAOCore(experiment.getId(), experiment.getTitle(), experiment.getDescription(),
                                  experiment.getInformedConsentForm(), experiment.getCreator(), 
-                                 experiment.getSignalingMechanisms(), experiment.getFixedDuration(),
+                                 experiment.getFixedDuration(),
                                  experiment.getStartDate(), experiment.getEndDate(), experiment.getJoinDate());
   }
 

--- a/Paco-Server/src/com/google/sampling/experiential/server/ExperimentRetriever.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/ExperimentRetriever.java
@@ -150,7 +150,7 @@ public class ExperimentRetriever {
     for (ExperimentDAO experiment : experiments) {
       String creatorEmail = experiment.getCreator().toLowerCase();
       if (creatorEmail.equals(email) || ExperimentRetriever.arrayContains(experiment.getAdmins(), email) || 
-          (experiment.getPublished() == true && 
+          (experiment.getPublished() != null && experiment.getPublished() == true &&
                   (experiment.getPublishedUsers().length == 0 || ExperimentRetriever.arrayContains(experiment.getPublishedUsers(), email)))) {
         availableExperiments.add(experiment);
       }

--- a/Paco/res/layout/experiment_detail_part.xml
+++ b/Paco/res/layout/experiment_detail_part.xml
@@ -42,9 +42,14 @@
 			<LinearLayout android:layout_width="wrap_content"
                 android:layout_height="wrap_content" android:orientation="vertical"
                 android:layout_gravity="left">
-                <LinearLayout android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" android:orientation="vertical"
-                    android:layout_gravity="left">
+
+                <LinearLayout
+                    android:id="@+id/scheduleDisplayPanel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="left"
+                    android:orientation="vertical" >
+
                     <TextView android:layout_width="wrap_content"
                         android:layout_height="wrap_content" android:textStyle="bold"
                         android:text="@string/schedule" android:layout_gravity="left"></TextView>

--- a/Paco/src/com/google/android/apps/paco/ExperimentDetailActivity.java
+++ b/Paco/src/com/google/android/apps/paco/ExperimentDetailActivity.java
@@ -115,16 +115,19 @@ public class ExperimentDetailActivity extends Activity {
     ((TextView)findViewById(R.id.description)).setText(experiment.getDescription());
     ((TextView)findViewById(R.id.creator)).setText(experiment.getCreator());
 
-    SignalSchedule schedule = experiment.getSchedule();
-    Trigger trigger = experiment.getTrigger();
-    if (schedule != null && trigger == null) {
-      Integer scheduleType = schedule.getScheduleType();
-      int scheduleName = SignalSchedule.SCHEDULE_TYPES_NAMES[scheduleType];
-      ((TextView) findViewById(R.id.schedule)).setText(scheduleName);
-    } else if (trigger != null) {
-      String triggerDetails = Trigger.getNameForCode(trigger.getEventCode());
-      ((TextView) findViewById(R.id.schedule)).setText(triggerDetails);
-    }
+//    SignalSchedule schedule = experiment.getSchedule();
+//    Trigger trigger = experiment.getTrigger();
+//    if (schedule != null && trigger == null) {
+//      Integer scheduleType = schedule.getScheduleType();
+//      int scheduleName = SignalSchedule.SCHEDULE_TYPES_NAMES[scheduleType];
+//      ((TextView) findViewById(R.id.schedule)).setText(scheduleName);
+//    } else if (trigger != null) {
+//      String triggerDetails = Trigger.getNameForCode(trigger.getEventCode());
+//      ((TextView) findViewById(R.id.schedule)).setText(triggerDetails);
+//    }
+    
+    // Hide the schedule panel for now (a short experiment load comes with no schedule info).
+    findViewById(R.id.scheduleDisplayPanel).setVisibility(View.GONE);
     
     String startDate = getString(R.string.ongoing_duration);
     String endDate = getString(R.string.ongoing_duration);
@@ -141,18 +144,19 @@ public class ExperimentDetailActivity extends Activity {
     ((TextView)findViewById(R.id.startDate)).setText(startDate);
     ((TextView)findViewById(R.id.endDate)).setText(endDate);
 
-    String esm_frequency = schedule != null && schedule.getEsmFrequency() != null 
-      ? schedule.getEsmFrequency().toString() 
-      : null;
-    if (schedule != null && schedule.getScheduleType() == SignalSchedule.ESM && esm_frequency != null && esm_frequency.length() > 0) {
-      findViewById(R.id.esmPanel).setVisibility(View.VISIBLE); 
-      ((TextView)findViewById(R.id.esm_frequency)).setText(esm_frequency+ "/" + getString(SignalSchedule.ESM_PERIODS_NAMES[schedule.getEsmPeriodInDays()]));
-    }
-    // TODO (bobevans): Update to show all the new shceduling types in a succinct readonly way
-    if (isJoinedExperiment()) {
-      findViewById(R.id.timePanel).setVisibility(View.VISIBLE); 
-      ((TextView)findViewById(R.id.time)).setText(toCommaSeparatedString(schedule != null ? schedule.getTimes() : null));
-    }
+//    String esm_frequency = schedule != null && schedule.getEsmFrequency() != null 
+//      ? schedule.getEsmFrequency().toString() 
+//      : null;
+//    if (schedule != null && schedule.getScheduleType() == SignalSchedule.ESM && esm_frequency != null && esm_frequency.length() > 0) {
+//      findViewById(R.id.esmPanel).setVisibility(View.VISIBLE); 
+//      ((TextView)findViewById(R.id.esm_frequency)).setText(esm_frequency+ "/" + getString(SignalSchedule.ESM_PERIODS_NAMES[schedule.getEsmPeriodInDays()]));
+//    }
+//    // TODO (bobevans): Update to show all the new shceduling types in a succinct readonly way
+//    if (isJoinedExperiment()) {
+//      findViewById(R.id.timePanel).setVisibility(View.VISIBLE); 
+//      ((TextView)findViewById(R.id.time)).setText(toCommaSeparatedString(schedule != null ? schedule.getTimes() : null));
+//    }
+    
     if (!isJoinedExperiment()) {
       joinButton.setOnClickListener(new OnClickListener() {    	 
         public void onClick(View v) {

--- a/Paco/src/com/google/android/apps/paco/InformedConsentActivity.java
+++ b/Paco/src/com/google/android/apps/paco/InformedConsentActivity.java
@@ -1,27 +1,41 @@
 /*
-* Copyright 2011 Google Inc. All Rights Reserved.
-* 
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance  with the License.  
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright 2011 Google Inc. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance  with the License.  
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.google.android.apps.paco;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.joda.time.DateTime;
+
+import com.google.common.base.Preconditions;
 import com.pacoapp.paco.R;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.CheckBox;
@@ -30,9 +44,14 @@ import android.widget.Toast;
 
 public class InformedConsentActivity extends Activity {
 
+  public static final int REFRESHING_JOINED_EXPERIMENT_DIALOG_ID = 1002;
+
   private Uri uri;
   private Experiment experiment;
   private boolean showingJoinedExperiments;
+
+  private ExperimentProviderUtil experimentProviderUtil;
+  private DownloadFullExperimentsTask experimentDownloadTask;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -40,37 +59,42 @@ public class InformedConsentActivity extends Activity {
     setContentView(R.layout.informed_consent);
     final Intent intent = getIntent();
     uri = intent.getData();
-    showingJoinedExperiments = intent.getData().equals(ExperimentColumns.JOINED_EXPERIMENTS_CONTENT_URI);
-    if (showingJoinedExperiments) {
-      experiment = new ExperimentProviderUtil(this).getExperiment(uri);
-    } else {
-      experiment = new ExperimentProviderUtil(this).getExperimentFromDisk(uri);
-    }
-    if (experiment == null) {
-      Toast.makeText(this, R.string.cannot_find_the_experiment_warning, Toast.LENGTH_SHORT).show();
-      finish();
-    } else {
-      // TextView title = (TextView)findViewById(R.id.experimentNameIc);
-      // title.setText(experiment.getTitle());
+    if (uri != null) {
+      showingJoinedExperiments = intent.getData().equals(ExperimentColumns.JOINED_EXPERIMENTS_CONTENT_URI);
+      experimentProviderUtil = new ExperimentProviderUtil(this);
+      if (showingJoinedExperiments) {
+        experiment = experimentProviderUtil.getExperiment(uri);
+      } else {
+        experiment = experimentProviderUtil.getExperimentFromDisk(uri);
+      }
+      if (experiment == null) {
+        Toast.makeText(this, R.string.cannot_find_the_experiment_warning, Toast.LENGTH_SHORT).show();
+        finish();
+      } else {
+        // TextView title = (TextView)findViewById(R.id.experimentNameIc);
+        // title.setText(experiment.getTitle());
 
-      TextView ic = (TextView) findViewById(R.id.InformedConsentTextView);
-      ic.setText(experiment.getInformedConsentForm());
+        TextView ic = (TextView) findViewById(R.id.InformedConsentTextView);
+        ic.setText(experiment.getInformedConsentForm());
 
-      if (experiment.getJoinDate() == null) {
-        final CheckBox icCheckbox = (CheckBox) findViewById(R.id.InformedConsentAgreementCheckBox);
-        icCheckbox.setOnClickListener(new OnClickListener() {
-          public void onClick(View v) {
-            if (icCheckbox.isChecked()) {
-              Intent intent = new Intent(InformedConsentActivity.this,
-                  ExperimentScheduleActivity.class);
-              intent.setAction(Intent.ACTION_EDIT);
-              intent.setData(uri);
-              startActivityForResult(intent, FindExperimentsActivity.JOIN_REQUEST_CODE);
+        if (experiment.getJoinDate() == null) {
+          final CheckBox icCheckbox = (CheckBox) findViewById(R.id.InformedConsentAgreementCheckBox);
+          icCheckbox.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+              if (icCheckbox.isChecked()) {
+                requestFullExperimentForJoining();
+              }
             }
-          }
-        });
+          });
+        }
       }
     }
+  }
+
+  // Visible for testing
+  public void setActivityProperties(Experiment experiment, ExperimentProviderUtil experimentProviderUtil) {
+    this.experiment = experiment;
+    this.experimentProviderUtil = experimentProviderUtil;
   }
 
   @Override
@@ -83,5 +107,183 @@ public class InformedConsentActivity extends Activity {
       }
     }
   }
+
+  private void requestFullExperimentForJoining() {
+    if (!NetworkUtil.isConnected(this)) {
+      showDialog(DownloadHelper.NO_NETWORK_CONNECTION, null);
+    } else {
+      DownloadFullExperimentsTaskListener listener = new DownloadFullExperimentsTaskListener() {
+
+        @Override
+        public void done(String resultCode) {
+          dismissDialog(REFRESHING_JOINED_EXPERIMENT_DIALOG_ID);
+          if (resultCode.equals(DownloadHelper.SUCCESS)) {
+            saveDownloadedExperimentBeforeScheduling();
+          } else {
+            showFailureDialog(resultCode);
+          }
+        }
+      };
+      showDialog(REFRESHING_JOINED_EXPERIMENT_DIALOG_ID, null);
+
+      List<Long> experimentServerIds = Arrays.asList(experiment.getServerId());
+      experimentDownloadTask = new DownloadFullExperimentsTask(this, listener, new UserPreferences(this), 
+                                                               experimentServerIds);
+      experimentDownloadTask.execute();
+    }
+  }
+
+  private void saveDownloadedExperimentBeforeScheduling() {
+    List<Experiment> experimentList = getDownloadedExperimentsList();
+    Preconditions.checkArgument(experimentList.size() == 1);
+    saveDownloadedExperimentBeforeScheduling(experimentList.get(0));
+  }
+
+  private List<Experiment> getDownloadedExperimentsList() {
+    String contentAsString = experimentDownloadTask.getContentAsString();
+    List<Experiment> experimentList;
+    try {
+      experimentList = ExperimentProviderUtil.getExperimentsFromJson(contentAsString);
+    } catch (JsonParseException e) {
+      showDialog(DownloadHelper.SERVER_ERROR, null);
+      return null;
+    } catch (JsonMappingException e) {
+      showDialog(DownloadHelper.SERVER_ERROR, null);
+      return null;
+    } catch (IOException e) {
+      showDialog(DownloadHelper.SERVER_ERROR, null);
+      return null;
+    }
+    return experimentList;
+  }
+
+  // Visible for testing
+  public void saveDownloadedExperimentBeforeScheduling(Experiment fullExperiment) {
+    experiment = fullExperiment;
+    joinExperiment();
+    runScheduleActivity();
+  }
+
+  private void runScheduleActivity() {
+    Intent intent = new Intent(InformedConsentActivity.this,
+                               ExperimentScheduleActivity.class);
+    intent.setAction(Intent.ACTION_EDIT);
+    intent.setData(uri);
+    startActivityForResult(intent, FindExperimentsActivity.JOIN_REQUEST_CODE);
+  }
+
+  private void joinExperiment() {
+    experiment.setJoinDate(getTodayAsStringWithZone());
+    // Set the uri to refer to the experiment's new saved location.
+    uri = experimentProviderUtil.insertFullJoinedExperiment(experiment);
+    createJoinEvent();
+    startService(new Intent(this, SyncService.class));
+  }
+
+  /**
+   * Creates a pacot for a newly registered experiment
+   */
+  private void createJoinEvent() {
+    Event event = new Event();
+    event.setExperimentId(experiment.getId());
+    event.setServerExperimentId(experiment.getServerId());
+    event.setExperimentName(experiment.getTitle());
+    event.setExperimentVersion(experiment.getVersion());
+    event.setResponseTime(new DateTime());
+
+    Output responseForInput = new Output();
+    responseForInput.setAnswer("true");
+    responseForInput.setName("joined");
+    event.addResponse(responseForInput);
+
+    Output responseForSchedule = new Output();
+    SignalingMechanism schedule = experiment.getSignalingMechanisms().get(0);
+    responseForSchedule.setAnswer(schedule.toString());
+    responseForSchedule.setName("schedule");
+    event.addResponse(responseForSchedule);
+
+    experimentProviderUtil.insertEvent(event);
+  }
+
+  protected Dialog onCreateDialog(int id, Bundle args) {
+    switch (id) {
+    case REFRESHING_JOINED_EXPERIMENT_DIALOG_ID: {
+      return getRefreshJoinedDialog();
+    } case DownloadHelper.INVALID_DATA_ERROR: {
+      return getUnableToJoinDialog(getString(R.string.invalid_data));
+    } case DownloadHelper.SERVER_ERROR: {
+      return getUnableToJoinDialog(getString(R.string.dialog_dismiss));
+    } case DownloadHelper.NO_NETWORK_CONNECTION: {
+      return getNoNetworkDialog();
+    } default: {
+      return null;
+    }
+    }
+  }
+
+  @Override
+  protected Dialog onCreateDialog(int id) {
+    return super.onCreateDialog(id);
+  }
+
+  private ProgressDialog getRefreshJoinedDialog() {
+    return ProgressDialog.show(this, getString(R.string.experiment_retrieval),
+                               getString(R.string.retrieving_your_joined_experiment_from_the_server), 
+                               true, true);
+  }
+
+  private AlertDialog getUnableToJoinDialog(String message) {
+    AlertDialog.Builder unableToJoinBldr = new AlertDialog.Builder(this);
+    unableToJoinBldr.setTitle(R.string.experiment_could_not_be_retrieved)
+    .setMessage(message)
+    .setPositiveButton(R.string.dialog_dismiss, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int which) {
+        setResult(FindExperimentsActivity.JOINED_EXPERIMENT);
+        finish();
+      }
+    });
+    return unableToJoinBldr.create();
+  }
+
+  private AlertDialog getNoNetworkDialog() {
+    AlertDialog.Builder noNetworkBldr = new AlertDialog.Builder(this);
+    noNetworkBldr.setTitle(R.string.network_required)
+    .setMessage(getString(R.string.need_network_connection))
+    .setPositiveButton(R.string.go_to_network_settings, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int which) {
+        showNetworkConnectionActivity();
+      }
+    })
+    .setNegativeButton(R.string.no_thanks, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int which) {
+        setResult(FindExperimentsActivity.JOINED_EXPERIMENT);
+        finish();
+      }
+    });
+    return noNetworkBldr.create();
+  }
+
+  private void showNetworkConnectionActivity() {
+    startActivityForResult(new Intent(Settings.ACTION_WIRELESS_SETTINGS), DownloadHelper.ENABLED_NETWORK);
+  }
+
+  private void showFailureDialog(String status) {
+    if (status.equals(DownloadHelper.CONTENT_ERROR) ||
+        status.equals(DownloadHelper.RETRIEVAL_ERROR)) {
+      showDialog(DownloadHelper.INVALID_DATA_ERROR, null);
+    } else {
+      showDialog(DownloadHelper.SERVER_ERROR, null);
+    }      
+  }
+
+  private String getTodayAsStringWithZone() {
+    return TimeUtil.formatDateWithZone(new DateTime());
+  }
+
+  // Visible for testing
+  public Uri getExperimentUri() {
+    return uri;
+  }
+
 
 }

--- a/PacoTest/src/com/google/android/apps/paco/test/ExperimentScheduleActivityTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/ExperimentScheduleActivityTest.java
@@ -7,18 +7,15 @@ import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.joda.time.DateTime;
 
+import android.content.Context;
+import android.content.Intent;
+import android.test.ActivityUnitTestCase;
+
 import com.google.android.apps.paco.Experiment;
 import com.google.android.apps.paco.ExperimentProviderUtil;
 import com.google.android.apps.paco.ExperimentScheduleActivity;
 import com.google.android.apps.paco.SignalSchedule;
 import com.google.android.apps.paco.TimeUtil;
-import com.google.common.collect.Lists;
-
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Bundle;
-import android.test.ActivityUnitTestCase;
 
 /*
  * TODO: Make this into instrumentation testing, changing the experiment schedule
@@ -30,8 +27,6 @@ import android.test.ActivityUnitTestCase;
  */
 public class ExperimentScheduleActivityTest extends ActivityUnitTestCase<ExperimentScheduleActivity> {
 
-  private ExperimentScheduleActivity activity;
-
   private static final Long START_TIME = Long.valueOf(500000);
   private static final Long END_TIME = Long.valueOf(1000000);
   private static final Integer REPEAT_RATE = 4;
@@ -39,12 +34,10 @@ public class ExperimentScheduleActivityTest extends ActivityUnitTestCase<Experim
   private static final Integer DAY_OF_MONTH = 4;
   private static final Integer DAY_OF_WEEK = 2;
 
+  private ExperimentScheduleActivity activity;
   private MockExperimentProviderUtil experimentProviderUtil;
   private Context context;
-
   private Intent intent;
-  private Bundle bundle;
-
   private long experimentId = 0;
 
   public ExperimentScheduleActivityTest() {
@@ -157,98 +150,6 @@ public class ExperimentScheduleActivityTest extends ActivityUnitTestCase<Experim
     checkSavedExperimentMonthlyNthOfMonthSchedule(savedExperiment);
   }
 
-  public void testEsmJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.FIXED_ESM);
-    configureActivityForTesting(experiment);
-
-    setActivityExperimentEsmSchedule();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentEsmSchedule(savedExperiment);
-  }
-
-  public void testWeekdayJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.FIXED_WEEKDAY);
-    configureActivityForTesting(experiment);
-
-    int timesLength = setActivityExperimentRepeatRateAndTimes();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentRepeatRateAndTimes(timesLength, savedExperiment);
-  }
-
-  public void testDailyJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.ONGOING_DAILY);
-    configureActivityForTesting(experiment);
-
-    int timesLength = setActivityExperimentRepeatRateAndTimes();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentRepeatRateAndTimes(timesLength, savedExperiment);
-  }
-
-  public void testWeeklyJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.ONGOING_WEEKLY);
-    configureActivityForTesting(experiment);
-
-    int timesLength = setActivityExperimentWeeklySchedule();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentWeeklySchedule(timesLength, savedExperiment);
-  }
-
-  public void testMonthlyDayOfMonthJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.ONGOING_MONTHLY);
-    configureActivityForTesting(experiment);
-
-    setActivityExperimentMonthlyDayOfMonthSchedule();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentMonthlyDayOfMonthSchedule(savedExperiment);
-  }
-
-  public void testMonthlyNthOfMonthJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.ONGOING_MONTHLY);
-    configureActivityForTesting(experiment);
-
-    setActivityExperimentMonthlyNthOfMonthSchedule();
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-    checkSavedExperimentMonthlyNthOfMonthSchedule(savedExperiment);
-  }
-
-  public void testSelfReportJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.FIXED_SELFREPORT);
-    configureActivityForTesting(experiment);
-
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-  }
-
-  public void testTriggeredJoining() {
-    Experiment experiment = getTestExperiment(ExperimentTestConstants.ONGOING_TRIGGERED);
-    configureActivityForTesting(experiment);
-
-    simulateDownloadingAndSchedulingExperiment(experiment);
-
-    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
-    checkExperimentProperlyJoined(savedExperiment);
-  }
-
   private Experiment getTestExperiment(String experimentTitle) {
     Experiment experiment = getExperimentFromJson(experimentTitle);
     experiment.setId(experimentId++);
@@ -284,20 +185,11 @@ public class ExperimentScheduleActivityTest extends ActivityUnitTestCase<Experim
   }
 
   private void configureActivityForTesting(Experiment experiment) {
-    activity.setActivityProperties(experiment, experimentProviderUtil, true);
+    activity.setActivityProperties(experiment, experimentProviderUtil);
   }
   
   private void saveExperimentSchedule() {
     activity.scheduleExperiment();
-  }
-
-  private void simulateDownloadingAndSchedulingExperiment(Experiment experiment) {
-    activity.saveDownloadedExperiment(experiment);
-  }
-
-  private void checkExperimentProperlyJoined(Experiment savedExperiment) {
-    assertNotNull(savedExperiment);
-    assertNotNull(savedExperiment.getJoinDate());
   }
 
   private void checkSavedExperimentEsmSchedule(Experiment savedExperiment) {
@@ -388,64 +280,4 @@ public class ExperimentScheduleActivityTest extends ActivityUnitTestCase<Experim
       assertEquals(newTimes.get(j), ADAPTER_TIME);
     }
   }
-
-  private class MockExperimentProviderUtil extends ExperimentProviderUtil {
-
-    private List<Experiment> experimentList;
-
-    MockExperimentProviderUtil(Context context) {
-      super(context);
-      experimentList = Lists.newArrayList();
-    }
-
-    @Override
-    public Uri insertFullJoinedExperiment(Experiment experiment) {
-      experimentList.add(experiment);
-      return Uri.parse("http://www.thisIsATest.com");
-    }
-
-    @Override
-    public int deleteNotificationsForExperiment(Long experimentId) {
-      return 0;
-    }
-
-    @Override
-    public void updateJoinedExperiment(Experiment experiment) {
-      Experiment experimentToDelete = null;
-      for (Experiment e : experimentList) {
-        if (e.getId().equals(experiment.getId())) {
-          experimentToDelete = e;
-        }
-      }
-      if (experimentToDelete != null) {
-        experimentList.remove(experimentToDelete);
-        experimentList.add(experiment);
-      }
-    }
-
-    @Override
-    public Experiment getExperiment(long experimentId) {
-      for (Experiment e : experimentList) {
-        if (e.getId().equals(experimentId)) {
-          return e;
-        }
-      }
-      return null;
-    }
-
-    @Override
-    public void deleteExperiment(long experimentId) {
-      Experiment experimentToDelete = null;
-      for (Experiment e : experimentList) {
-        if (e.getId().equals(experimentId)) {
-          experimentToDelete = e;
-        }
-      }
-      if (experimentToDelete != null) {
-        experimentList.remove(experimentToDelete);
-      }
-    }
-
-  }
-
 }

--- a/PacoTest/src/com/google/android/apps/paco/test/InformedConsentActivityTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/InformedConsentActivityTest.java
@@ -1,0 +1,99 @@
+package com.google.android.apps.paco.test;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.test.ActivityUnitTestCase;
+
+import com.google.android.apps.paco.Experiment;
+import com.google.android.apps.paco.ExperimentColumns;
+import com.google.android.apps.paco.ExperimentProviderUtil;
+import com.google.android.apps.paco.InformedConsentActivity;
+
+public class InformedConsentActivityTest extends ActivityUnitTestCase<InformedConsentActivity> {
+
+  private InformedConsentActivity activity;
+  private MockExperimentProviderUtil experimentProviderUtil;
+  private Context context;
+  private Intent intent;
+  private long experimentId = 0;
+
+  public InformedConsentActivityTest() {
+    super(InformedConsentActivity.class);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    context = getInstrumentation().getContext();
+    experimentProviderUtil = new MockExperimentProviderUtil(context);
+    intent = new Intent();
+    startActivity(intent, null, null);
+    activity = getActivity();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    activity.finish();
+  }
+
+  public void testExperimentJoining() {
+    Experiment experiment = getTestExperiment(ExperimentTestConstants.FIXED_ESM);
+    configureActivityForTesting(experiment);
+
+    simulateDownloadingAndSavingExperiment(experiment);
+
+    checkExperimentUriProperlyUpdated();
+    Experiment savedExperiment = experimentProviderUtil.getExperiment(experiment.getId());
+    checkExperimentProperlyJoined(savedExperiment);
+
+  }
+
+  private Experiment getTestExperiment(String experimentTitle) {
+    Experiment experiment = getExperimentFromJson(experimentTitle);
+    experiment.setId(experimentId++);
+    return experiment;
+  }
+
+  private Experiment getExperimentFromJson(String contentAsString) {
+    try {
+      Experiment experiment = ExperimentProviderUtil.getSingleExperimentFromJson(contentAsString);
+      return experiment;
+    } catch (JsonParseException e) {
+      assertTrue(false);
+      return null;
+    } catch (JsonMappingException e) {
+      assertTrue(false);
+      return null;
+    } catch (IOException e) {
+      assertTrue(false);
+      return null;
+    }
+  }
+  
+  private void configureActivityForTesting(Experiment experiment) {
+    activity.setActivityProperties(experiment, experimentProviderUtil);
+  }
+
+  private void simulateDownloadingAndSavingExperiment(Experiment experiment) {
+    activity.saveDownloadedExperimentBeforeScheduling(experiment);
+  }
+  
+  private void checkExperimentUriProperlyUpdated() {
+    Uri uri = activity.getExperimentUri();
+    assertTrue(uri.getPathSegments().get(0)
+    .equals(ExperimentColumns.JOINED_EXPERIMENTS_CONTENT_URI.getPathSegments().get(0)));
+  }
+
+  private void checkExperimentProperlyJoined(Experiment savedExperiment) {
+    assertNotNull(savedExperiment);
+    assertNotNull(savedExperiment.getJoinDate());
+  }
+
+}

--- a/PacoTest/src/com/google/android/apps/paco/test/MockExperimentProviderUtil.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/MockExperimentProviderUtil.java
@@ -1,0 +1,71 @@
+package com.google.android.apps.paco.test;
+
+import java.util.List;
+
+import android.content.Context;
+import android.net.Uri;
+
+import com.google.android.apps.paco.Experiment;
+import com.google.android.apps.paco.ExperimentColumns;
+import com.google.android.apps.paco.ExperimentProviderUtil;
+import com.google.common.collect.Lists;
+
+class MockExperimentProviderUtil extends ExperimentProviderUtil {
+
+  private List<Experiment> experimentList;
+
+  MockExperimentProviderUtil(Context context) {
+    super(context);
+    experimentList = Lists.newArrayList();
+  }
+
+  @Override
+  public Uri insertFullJoinedExperiment(Experiment experiment) {
+    experimentList.add(experiment);
+    // The uri of a joined experiment has this as its first segment.
+    return Uri.parse(ExperimentColumns.JOINED_EXPERIMENTS_CONTENT_URI.getPathSegments().get(0));
+  }
+
+  @Override
+  public int deleteNotificationsForExperiment(Long experimentId) {
+    return 0;
+  }
+
+  @Override
+  public void updateJoinedExperiment(Experiment experiment) {
+    Experiment experimentToDelete = null;
+    for (Experiment e : experimentList) {
+      if (e.getId().equals(experiment.getId())) {
+        experimentToDelete = e;
+      }
+    }
+    if (experimentToDelete != null) {
+      experimentList.remove(experimentToDelete);
+      experimentList.add(experiment);
+    }
+  }
+
+  @Override
+  public Experiment getExperiment(long experimentId) {
+    for (Experiment e : experimentList) {
+      if (e.getId().equals(experimentId)) {
+        return e;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void deleteExperiment(long experimentId) {
+    Experiment experimentToDelete = null;
+    for (Experiment e : experimentList) {
+      if (e.getId().equals(experimentId)) {
+        experimentToDelete = e;
+      }
+    }
+    if (experimentToDelete != null) {
+      experimentList.remove(experimentToDelete);
+    }
+  }
+
+}

--- a/Shared/src/com/google/paco/shared/model/ExperimentDAO.java
+++ b/Shared/src/com/google/paco/shared/model/ExperimentDAO.java
@@ -36,6 +36,10 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
   /**
    * 
    */
+  
+  public static final int SCHEDULED_SIGNALING = 1;
+  public static final int TRIGGERED_SIGNALING = 1;
+  
   private Boolean questionsChange = false;
 
   private String hash;
@@ -48,6 +52,9 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
   private Boolean deleted = false;
   private Boolean webRecommended = false;
   private Integer version;
+  protected SignalingMechanismDAO[] signalingMechanisms;
+  protected SignalScheduleDAO schedule;
+  
   /**
    * @param id
    * @param title
@@ -65,13 +72,14 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
       String startDate, String endDate, String hash, String joinDate,
       String modifyDate, Boolean published, String[] admins, String[] publishedUsers, 
       Boolean deleted, Boolean webRecommended, Integer version) {
-    super(id, title, description, informedConsentForm, email, signalingMechanisms, fixedDuration, startDate, endDate, joinDate);
+    super(id, title, description, informedConsentForm, email, fixedDuration, startDate, endDate, joinDate);
     this.id = id;
     this.title = title;
     this.description = description;
     this.informedConsentForm = informedConsentForm;
     this.creator = email;
     this.signalingMechanisms = signalingMechanisms;
+    setScheduleForBackwardCompatibility();
     this.fixedDuration = fixedDuration;
     this.questionsChange = questionsChange;
     this.startDate = startDate;
@@ -194,6 +202,33 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
   
   public void setVersion(Integer version) {
     this.version = version;
+  }
+
+  public SignalingMechanismDAO[] getSignalingMechanisms() {
+    return signalingMechanisms;
+  }
+
+  public void setSignalingMechanisms(SignalingMechanismDAO[] signalingMechanisms) {
+    this.signalingMechanisms = signalingMechanisms;
+  }
+
+  public void setScheduleForBackwardCompatibility() {
+    if (getSignalingMechanisms() != null 
+            && getSignalingMechanisms().length > 0 
+            && getSignalingMechanisms()[0] instanceof SignalScheduleDAO) {
+      schedule = (SignalScheduleDAO) getSignalingMechanisms()[0];
+    } else {
+      schedule = new SignalScheduleDAO();
+      schedule.setScheduleType(SignalScheduleDAO.SELF_REPORT);
+    }
+  }
+
+  public SignalScheduleDAO getSchedule() {
+    return schedule;
+  }
+
+  public void setSchedule(SignalScheduleDAO schedule) {
+    this.schedule = schedule;
   }
   
   

--- a/Shared/src/com/google/paco/shared/model/ExperimentDAOCore.java
+++ b/Shared/src/com/google/paco/shared/model/ExperimentDAOCore.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 
 public class ExperimentDAOCore implements Serializable {
 
-  public static final int SCHEDULED_SIGNALING = 1;
-  public static final int TRIGGERED_SIGNALING = 1;
   protected String title;
   protected String description;
   protected String informedConsentForm;
@@ -15,11 +13,9 @@ public class ExperimentDAOCore implements Serializable {
   protected String endDate;
   protected String joinDate;
   protected Long id;
-  protected SignalingMechanismDAO[] signalingMechanisms;
-  protected SignalScheduleDAO schedule;
 
   public ExperimentDAOCore(Long id, String title, String description, String informedConsentForm,
-                           String email, SignalingMechanismDAO[] signalingMechanisms, Boolean fixedDuration, 
+                           String email, Boolean fixedDuration, 
                            String startDate, String endDate, String joinDate) {
     super();
     this.id = id;
@@ -27,8 +23,6 @@ public class ExperimentDAOCore implements Serializable {
     this.description = description;
     this.informedConsentForm = informedConsentForm;
     this.creator = email;
-    this.signalingMechanisms = signalingMechanisms;
-    setScheduleForBackwardCompatibility();
     this.fixedDuration = fixedDuration;
     this.startDate = startDate;
     this.endDate = endDate;
@@ -40,8 +34,6 @@ public class ExperimentDAOCore implements Serializable {
    */
   public ExperimentDAOCore() {
     super();
-    this.signalingMechanisms = new SignalingMechanismDAO[] { new SignalScheduleDAO()};
-    setScheduleForBackwardCompatibility();
   }
 
   public String getTitle() {
@@ -114,33 +106,6 @@ public class ExperimentDAOCore implements Serializable {
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public SignalingMechanismDAO[] getSignalingMechanisms() {
-    return signalingMechanisms;
-  }
-
-  public void setSignalingMechanisms(SignalingMechanismDAO[] signalingMechanisms) {
-    this.signalingMechanisms = signalingMechanisms;
-  }
-
-  public void setScheduleForBackwardCompatibility() {
-    if (getSignalingMechanisms() != null 
-            && getSignalingMechanisms().length > 0 
-            && getSignalingMechanisms()[0] instanceof SignalScheduleDAO) {
-      schedule = (SignalScheduleDAO) getSignalingMechanisms()[0];
-    } else {
-      schedule = new SignalScheduleDAO();
-      schedule.setScheduleType(SignalScheduleDAO.SELF_REPORT);
-    }
-  }
-
-  public SignalScheduleDAO getSchedule() {
-    return schedule;
-  }
-
-  public void setSchedule(SignalScheduleDAO schedule) {
-    this.schedule = schedule;
   }
 
 }


### PR DESCRIPTION
IMPORTANT: please see my inline github comments.  Since there is a lot of copy/paste, these comments draw attention to the important changes (which are hard to sniff out in the diffs).

Changed ExperimentDAOCore such that it no longer includes schedule/signaling params.

This change involved changing the flow on the Android client such that an experiment's full definition is loaded after the user agrees to the Informed Consent Form but before the user schedules the experiment.  Thus, there is a lot of copy/paste of code that used to be in ExperimentScheduleActivity into InformedConsentActivity.  Also, the MockExperimentProviderUtil previoulsy used in the ExperimentScheduleActivityTest is now available to the InformedConsentActivityTest as well.
