### PR TITLE
iOS: remove location key from info plist, since we don’t need it for sig...

### DIFF
--- a/Paco-iOS/Paco/config/Paco-Info.plist
+++ b/Paco-iOS/Paco/config/Paco-Info.plist
@@ -48,7 +48,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>location</string>
 	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>


### PR DESCRIPTION
...nificant location monitoring
