### PR TITLE
#711: Added notification information for Running Experiments

### DIFF
--- a/Paco-iOS/Paco/source/ui/RunningExperimentScreen/PacoRunningExperimentsViewController.m
+++ b/Paco-iOS/Paco/source/ui/RunningExperimentScreen/PacoRunningExperimentsViewController.m
@@ -130,7 +130,8 @@
       } else {
         NSDate *now = [NSDate date];
         NSInteger minutes = floor([now timeIntervalSinceDate:[notification pacoFireDate]] / 60);
-        cell.detailTextLabel.text = [NSString stringWithFormat:@"Active: Last notified %d minute(s) ago", minutes];
+        NSString *minuteString = minutes > 1 ? @"minutes" : @"minute";
+        cell.detailTextLabel.text = [NSString stringWithFormat:@"Active: Last notified %d %@ ago", minutes, minuteString];
         cell.detailTextLabel.textColor = [UIColor redColor];
       }
     }


### PR DESCRIPTION
Attaching a screenshot of the view after changes.
![screen shot 2014-02-08 at 2 08 21 am](https://f.cloud.github.com/assets/648813/2114394/c4d2ab9c-903c-11e3-86a4-b61d95279da8.png)
