### PR TITLE
Changed hard paths to relative ones.

### DIFF
--- a/Paco-Server/.classpath
+++ b/Paco-Server/.classpath
@@ -22,13 +22,13 @@
 	<classpathentry kind="lib" path="war/WEB-INF/lib/gwt-incubator.jar"/>
 	<classpathentry kind="lib" path="war/WEB-INF/lib/gwt-maps-api-3.10.0-alpha-7-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="war/WEB-INF/lib/gwt-ajaxloader.jar"/>
-	<classpathentry kind="con" path="com.google.gwt.eclipse.core.GWT_CONTAINER/gwt-2.6.0"/>
-	<classpathentry kind="lib" path="/Users/bobevans/git/paco/tools/appengine-java-sdk-1.9.0/lib/testing/appengine-testing.jar"/>
+	<classpathentry kind="con" path="com.google.gwt.eclipse.core.GWT_CONTAINER"/>
+	<classpathentry kind="lib" path="../paco/tools/appengine-java-sdk-1.9.0/lib/testing/appengine-testing.jar"/>
 	<classpathentry kind="lib" path="war/WEB-INF/lib/guava-16.0.1.jar"/>
 	<classpathentry kind="lib" path="war/WEB-INF/lib/guava-gwt-16.0.1.jar"/>
-	<classpathentry kind="lib" path="/Users/bobevans/git/paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api.jar"/>
-	<classpathentry kind="lib" path="/Users/bobevans/git/paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api-stubs.jar"/>
-	<classpathentry kind="lib" path="/Users/bobevans/git/paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api-labs.jar"/>
-	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER/appengine-java-sdk-1.9.0-paco"/>
+	<classpathentry kind="lib" path="../paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api.jar"/>
+	<classpathentry kind="lib" path="../paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api-stubs.jar"/>
+	<classpathentry kind="lib" path="../paco/tools/appengine-java-sdk-1.9.0/lib/impl/appengine-api-labs.jar"/>
+	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER"/>
 	<classpathentry kind="output" path="war/WEB-INF/classes"/>
 </classpath>


### PR DESCRIPTION
Other changes via Eclipse appear to have changed the GWT and App Engine
library references to default (version removed).