### PR TITLE
iOS 8 requires registering for localNotifications

### DIFF
--- a/Paco-iOS/Paco/source/PacoAppDelegate.m
+++ b/Paco-iOS/Paco/source/PacoAppDelegate.m
@@ -131,6 +131,12 @@
   logger.rollingFrequency = 2 * 24 * 60 * 60; //48 hours rolling
   logger.logFileManager.maximumNumberOfLogFiles = 7;
   [DDLog addLogger:logger];
+
+  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {   
+    UIUserNotificationType types = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
+    UIUserNotificationSettings *mySettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
+    [application registerUserNotificationSettings:mySettings];
+  }
   
   // Override the navigation bar and item tint color globally across the app.
   [[UINavigationBar appearance] setTintColor:[UIColor pacoBlue]];

--- a/Paco-iOS/Paco/source/PacoAppDelegate.m
+++ b/Paco-iOS/Paco/source/PacoAppDelegate.m
@@ -132,7 +132,8 @@
   logger.logFileManager.maximumNumberOfLogFiles = 7;
   [DDLog addLogger:logger];
 
-  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {   
+  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1 ||
+      [UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
     UIUserNotificationType types = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
     UIUserNotificationSettings *mySettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
     [application registerUserNotificationSettings:mySettings];


### PR DESCRIPTION
 otherwise, sometimes they don't work. This is not necessary on 7 (and the api didn't exist then) so I added a guard for the version of iOS running.

I was able to reproduce the problem seen at Kent State by running in a plain iPhone 6 simulator on iOS 8.1.

I also tested on an iOS 7.1 simulator iPhone 5, an iOS 8.1 simulator iPhone 5, and a real iPhone 5 running 8.1.2. All worked properly.

Anything else we need to consider for this change?