### PR TITLE
Release 1.1.6 with iOS version guard

### DIFF
--- a/Paco-iOS/Paco/source/PacoAppDelegate.m
+++ b/Paco-iOS/Paco/source/PacoAppDelegate.m
@@ -131,6 +131,12 @@
   logger.rollingFrequency = 2 * 24 * 60 * 60; //48 hours rolling
   logger.logFileManager.maximumNumberOfLogFiles = 7;
   [DDLog addLogger:logger];
+
+  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {   
+    UIUserNotificationType types = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
+    UIUserNotificationSettings *mySettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
+    [application registerUserNotificationSettings:mySettings];
+  }
   
   // Override the navigation bar and item tint color globally across the app.
   [[UINavigationBar appearance] setTintColor:[UIColor pacoBlue]];

--- a/Paco-iOS/Paco/source/PacoAppDelegate.m
+++ b/Paco-iOS/Paco/source/PacoAppDelegate.m
@@ -132,7 +132,8 @@
   logger.logFileManager.maximumNumberOfLogFiles = 7;
   [DDLog addLogger:logger];
 
-  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {   
+  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1 ||
+      [UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
     UIUserNotificationType types = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
     UIUserNotificationSettings *mySettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
     [application registerUserNotificationSettings:mySettings];


### PR DESCRIPTION
This is mostly the same pull request to include the registration of local notifications. It asks the user for permission on first launch. I also added a different guard to check that the selector exists before calling it in case we were on ios 7. Although, there is a guard for that, it would fail if Apple released any updates to ios 7 beyond 7.1.