### PR TITLE
Fixes response group issue #1004

### DIFF
--- a/Paco-Server/ear/default/web/js/controllers.js
+++ b/Paco-Server/ear/default/web/js/controllers.js
@@ -208,6 +208,9 @@ pacoApp.controller('ExperimentCtrl', ['$scope', '$http',
           } 
         }
         $scope.respondableGroups = groups;
+        if ($scope.respondableGroups.length === 1) {
+          $scope.state.groupIndex = 0;
+        }
       }
     });
 


### PR DESCRIPTION
Sets the group index to 0 if there is only one respondable group. Updated on pacostage.