### PR TITLE
Issue1214

### DIFF
--- a/Paco-Server/ear/default/web/css/experiment.css
+++ b/Paco-Server/ear/default/web/css/experiment.css
@@ -8,3 +8,8 @@
   font-size: 18px;
   font-weight: 400;
 }
+
+.nav button.md-button {
+  max-width: 360px;
+  text-overflow: ellipsis;
+}

--- a/Paco-Server/ear/default/web/css/experiment.css
+++ b/Paco-Server/ear/default/web/css/experiment.css
@@ -2,6 +2,7 @@
   font-size: 24px;
   font-weight: 400;
   margin: 0;
+  min-height: 32px;
 }
 
 .experiment h2 {
@@ -10,6 +11,8 @@
 }
 
 .nav button.md-button {
+  min-height: 16px;
+  min-width: 1px;
   max-width: 360px;
   text-overflow: ellipsis;
 }

--- a/Paco-Server/ear/default/web/css/list.css
+++ b/Paco-Server/ear/default/web/css/list.css
@@ -51,3 +51,11 @@
   right: 0px;
   z-index: 1;
 }
+
+.list .show-more button {
+  width: 100%;
+}
+
+.list md-progress-circular {
+  margin-left: calc(50% - 50px);
+}

--- a/Paco-Server/ear/default/web/css/list.css
+++ b/Paco-Server/ear/default/web/css/list.css
@@ -52,7 +52,7 @@
   z-index: 1;
 }
 
-.list .show-more button {
+.list button.show-more {
   width: 100%;
 }
 

--- a/Paco-Server/ear/default/web/js/app.js
+++ b/Paco-Server/ear/default/web/js/app.js
@@ -32,6 +32,7 @@ pacoApp.config(['$routeProvider','$locationProvider',
     }).
     when('/experiments', {
       templateUrl: 'partials/list.html',
+      reloadOnSearch: false,
     }).
     when('/copy/:copyId', {
       templateUrl: 'partials/edit.html',
@@ -39,12 +40,13 @@ pacoApp.config(['$routeProvider','$locationProvider',
     }).
     otherwise({
       templateUrl: 'partials/welcome.html',
+      reloadOnSearch: false,
     });
-
-    //$locationProvider.html5Mode(true);
   }
 ]);
 
+// Prevents a change in the hash parameter from jumping to internal anchors
+pacoApp.value('$anchorScroll', angular.noop);
 
 pacoApp.config(['$compileProvider',
   function ($compileProvider) {

--- a/Paco-Server/ear/default/web/js/controllers.js
+++ b/Paco-Server/ear/default/web/js/controllers.js
@@ -7,6 +7,10 @@ pacoApp.controller('HomeCtrl', ['$scope', '$http', '$location',
     $scope.loaded = false;
     $scope.edit = false;
 
+    $scope.home = function() {
+       document.location = '/';
+    };
+
     $scope.scrolling = function(flag) {
       if (flag) {
         angular.element(document.body).removeClass('no-scroll');

--- a/Paco-Server/ear/default/web/js/services.js
+++ b/Paco-Server/ear/default/web/js/services.js
@@ -283,7 +283,7 @@ pacoApp.service('config', function() {
     'when'
   ];
 
-  this.listPageSize = 5;
+  this.listPageSize = 10;
 });
 
 

--- a/Paco-Server/ear/default/web/js/services.js
+++ b/Paco-Server/ear/default/web/js/services.js
@@ -1,45 +1,58 @@
-pacoApp.service('experimentService', ['$http', '$cacheFactory', 'util',
-  function($http, $cacheFactory, util) {
+pacoApp.service('experimentService', ['$http', '$cacheFactory', 'config', 'util',
+  function($http, $cacheFactory, config, util) {
+
+    // Set this header here and it applies to all http requests
+    $http.defaults.headers.common['pacoProtocol'] = 4;
 
     var cache = $cacheFactory.get('$http');
 
     return ({
       deleteExperiment: deleteExperiment,
-      getAdministered: getAdministered,
-      getJoinable: getJoinable,
-      getJoined: getJoined,
+      getExperimentList: getExperimentList,
       getExperiment: getExperiment,
       joinExperiment: joinExperiment,
       saveExperiment: saveExperiment,
     });
 
+    function getExperimentList(listType, reload, cursor) {
+      var endpoint = '/experiments?' + listType;
 
-    function getJoined(reload) {
       if (reload !== undefined && reload === true) {
-        cache.remove('/experiments?joined');
+        cache.remove(endpoint);
       }
-      return $http.get('/experiments?joined', {
+
+      endpoint += '&limit=' + config.listPageSize;
+
+      if (cursor !== undefined) {
+        endpoint += '&cursor=' + cursor;
+      }
+
+      return $http.get(endpoint, {
         cache: true
       });
     }
 
-    function getAdministered(reload) {
-      if (reload !== undefined && reload === true) {
-        cache.remove('/experiments?admin');
-      }
-      return $http.get('/experiments?admin', {
-        cache: true
-      });
-    }
+    // function getJoined(reload) {
+    
+    // }
 
-    function getJoinable(reload) {
-      if (reload !== undefined && reload === true) {
-        cache.remove('/experiments?mine');
-      }
-      return $http.get('/experiments?mine', {
-        cache: true
-      });
-    }
+    // function getAdministered(reload) {
+    //   if (reload !== undefined && reload === true) {
+    //     cache.remove('/experiments?admin');
+    //   }
+    //   return $http.get('/experiments?admin&limit=3', {
+    //     cache: true
+    //   });
+    // }
+
+    // function getJoinable(reload) {
+    //   if (reload !== undefined && reload === true) {
+    //     cache.remove('/experiments?mine');
+    //   }
+    //   return $http.get('/experiments?mine', {
+    //     cache: true
+    //   });
+    // }
 
     function getExperiment(id) {
       return $http.get('/experiments?id=' + id, {
@@ -66,9 +79,9 @@ pacoApp.service('experimentService', ['$http', '$cacheFactory', 'util',
     function saveExperiment(experiment) {
 
       // Need to clear all list caches in case title was changed
-      cache.remove('/experiments?admin');
-      cache.remove('/experiments?joined');
-      cache.remove('/experiments?mine');
+      // cache.remove('/experiments?admin');
+      // cache.remove('/experiments?joined');
+      // cache.remove('/experiments?mine');
 
       // If it's not a new experiment, clear old cached definition
       if (experiment.id) {
@@ -262,6 +275,8 @@ pacoApp.service('config', function() {
     'scheduledTime',
     'when'
   ];
+
+  this.listPageSize = 5;
 });
 
 

--- a/Paco-Server/ear/default/web/partials/edit.html
+++ b/Paco-Server/ear/default/web/partials/edit.html
@@ -57,8 +57,7 @@
       </div>
 
       <md-tabs md-selected="state.tabId">
-        <!-- There is an error if md-on-select/deselect are not defined. -->
-        <md-tab ng-repeat="tab in tabs" md-on-select="" md-on-deselect="">
+        <md-tab ng-repeat="tab in tabs">
           <md-tab-label>
             {{tab}}
           </md-tab-label>

--- a/Paco-Server/ear/default/web/partials/experiment.html
+++ b/Paco-Server/ear/default/web/partials/experiment.html
@@ -1,9 +1,15 @@
 <div ng-controller="ExperimentCtrl" class="centered experiment">
-  <h2>
-    <a href="#">Experiments</a> &gt 
-    <a href="#/experiment/{{experiment.id}}">{{experiment.title}}</a> 
-    &gt; Description
-  </h2>
+  <div class="nav">
+    <a href="#/experiments">
+      <md-button>Experiments</md-button>
+    </a>
+    
+    <img src="/img/ic_chevron_right_24px.svg">
+
+    <a href="#/experiment/{{experiment.id}}">
+      <md-button>{{experiment.title}}</md-button>
+    </a>
+  </div>
 
   <md-card>
     <md-card-content>

--- a/Paco-Server/ear/default/web/partials/list.html
+++ b/Paco-Server/ear/default/web/partials/list.html
@@ -5,13 +5,10 @@
     </md-button>
   </a>
 
-  <md-tabs md-selected="listTab" md-dynamic-height md-center-tabs>
-
+  <md-tabs md-selected="state.listTab" md-dynamic-height md-center-tabs>
     <md-tab id="admin">
       <md-tab-label>Administered</md-tab-label>
       <md-tab-body>
-        <md-progress-circular md-mode="indeterminate" ng-if="loading.admin">
-        </md-progress-circular>
         <div ng-if="list.admin" class="group">
           <div ng-repeat="exp in list.admin">
             <md-card ng-class="{deleted: exp.deleted}">
@@ -60,18 +57,17 @@
           </div>
         </div>
 
-        <a href="#" class="show-more" ng-if="cursor.admin" ng-click="loadMore('admin')">
-          <md-button>Show More</md-button>
-        </a>
-
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.admin">
+        </md-progress-circular>
+        <md-button class="show-more" ng-if="cursor.admin" ng-click="loadMore('admin')">
+          Show More
+        </md-button>
       </md-tab-body>
     </md-tab>
 
     <md-tab id="joined">
       <md-tab-label>Joined</md-tab-label>
       <md-tab-body>
-        <md-progress-circular md-mode="indeterminate" ng-if="loading.joined">
-        </md-progress-circular>
         <div ng-if="list.joined" class="group">
           <div ng-repeat="exp in list.joined">
             <md-card>
@@ -103,35 +99,41 @@
           </div>
         </div>
 
-        <a href="#" class="show-more" ng-if="cursor.joined" ng-click="loadMore('joined')">
-          <md-button>Show More</md-button>
-        </a>
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.joined">
+        </md-progress-circular>
+        <md-button class="show-more" ng-if="cursor.joined" 
+          ng-click="loadMore('joined')">
+          Show More
+        </md-button>
       </md-tab-body>
     </md-tab>
 
     <md-tab id="joinable">
-      <md-tab-label>Joinable</md-tab-label>
+      <md-tab-label>Invited</md-tab-label>
       <md-tab-body>
-        <md-progress-circular md-mode="indeterminate" ng-if="loading.mine">
-        </md-progress-circular>
         <div ng-if="list.mine" class="group">
-          <div ng-repeat="exp in list.mine" ng-if="joinedIndex.indexOf(exp.id) === -1">
+          <div ng-repeat="exp in list.mine">
             <md-card>
               <md-card-content class="padded">
                 <a href="#/experiment/{{exp.id}}">{{exp.title}}</a>
                 <span ng-if="exp.organization" class="organization">
                   administered by {{exp.organization}}
                 </span>
-                <md-button ng-click="joinExperiment($event, exp)" class="join">
+                <md-button ng-click="joinExperiment($event, exp)" class="join"
+                  ng-disabled="joinedIndex.indexOf(exp.id) != -1">
                   Join
                 </md-button>
               </md-card-content>
             </md-card>
           </div>
         </div>
-        <a href="#" class="show-more" ng-if="cursor.mine" ng-click="loadMore('mine')">
-          <md-button>Show More</md-button>
-        </a>
+
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.mine">
+        </md-progress-circular>
+
+        <md-button ng-if="cursor.mine" class="show-more" ng-click="loadMore('mine')">
+          Show More
+        </md-button>
       </md-tab-body>
     </md-tab>
   </md-tabs>

--- a/Paco-Server/ear/default/web/partials/list.html
+++ b/Paco-Server/ear/default/web/partials/list.html
@@ -10,10 +10,10 @@
     <md-tab id="admin">
       <md-tab-label>Administered</md-tab-label>
       <md-tab-body>
-        <md-progress-circular md-mode="indeterminate" ng-if="!experiments && user">
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.admin">
         </md-progress-circular>
-        <div ng-if="experiments" class="group">
-          <div ng-repeat="exp in experiments | orderBy: 'title'">
+        <div ng-if="list.admin" class="group">
+          <div ng-repeat="exp in list.admin">
             <md-card ng-class="{deleted: exp.deleted}">
               <md-card-content class="padded">
                 <a href="#/experiment/{{exp.id}}">{{exp.title}}
@@ -59,14 +59,21 @@
             </md-card>
           </div>
         </div>
+
+        <a href="#" class="show-more" ng-if="cursor.admin" ng-click="loadMore('admin')">
+          <md-button>Show More</md-button>
+        </a>
+
       </md-tab-body>
     </md-tab>
 
     <md-tab id="joined">
       <md-tab-label>Joined</md-tab-label>
       <md-tab-body>
-        <div ng-if="joined" class="group">
-          <div ng-repeat="exp in joined | orderBy:'title'">
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.joined">
+        </md-progress-circular>
+        <div ng-if="list.joined" class="group">
+          <div ng-repeat="exp in list.joined">
             <md-card>
               <md-card-content class="padded">
                 <a href="#/experiment/{{exp.id}}">{{exp.title}}</a>
@@ -93,17 +100,22 @@
                 </a>
               </div>
             </md-card>
-
           </div>
         </div>
+
+        <a href="#" class="show-more" ng-if="cursor.joined" ng-click="loadMore('joined')">
+          <md-button>Show More</md-button>
+        </a>
       </md-tab-body>
     </md-tab>
 
     <md-tab id="joinable">
       <md-tab-label>Joinable</md-tab-label>
       <md-tab-body>
-        <div ng-if="joinable" class="group">
-          <div ng-repeat="exp in joinable" ng-if="joinedIndex.indexOf(exp.id) === -1">
+        <md-progress-circular md-mode="indeterminate" ng-if="loading.mine">
+        </md-progress-circular>
+        <div ng-if="list.mine" class="group">
+          <div ng-repeat="exp in list.mine" ng-if="joinedIndex.indexOf(exp.id) === -1">
             <md-card>
               <md-card-content class="padded">
                 <a href="#/experiment/{{exp.id}}">{{exp.title}}</a>
@@ -117,6 +129,9 @@
             </md-card>
           </div>
         </div>
+        <a href="#" class="show-more" ng-if="cursor.mine" ng-click="loadMore('mine')">
+          <md-button>Show More</md-button>
+        </a>
       </md-tab-body>
     </md-tab>
   </md-tabs>

--- a/Paco-Server/ear/default/web/partials/menu.html
+++ b/Paco-Server/ear/default/web/partials/menu.html
@@ -1,5 +1,5 @@
 <md-toolbar class="md-tall md-menu-toolbar">
-  <a href="/">
+  <a href="#" ng-click="home()">
     <img src="img/paco256.png" class="paco">
   </a>
   <span class="title">Paco</span>

--- a/Paco-Server/ear/default/web/partials/respond.html
+++ b/Paco-Server/ear/default/web/partials/respond.html
@@ -1,11 +1,25 @@
 <div ng-controller="ExperimentCtrl" class="centered">
   
-  <div class="padded">
-    <a href="#">Experiments</a> &gt
-    <a href="#/experiment/{{respondExperimentId}}">{{experiment.title}}</a> &gt; 
-    Respond    
+  <div class="nav">
+    <a href="#/experiments">
+      <md-button>
+        Experiments
+      </md-button>
+    </a>
 
+    <img src="/img/ic_chevron_right_24px.svg">
+
+    <a href="#/experiment/{{respondExperimentId}}">
+      <md-button>{{experiment.title}}</md-button>
+    </a>
+
+    <img src="/img/ic_chevron_right_24px.svg">
+
+    <a href="#/respond/{{respondExperimentId}}">
+      <md-button>Respond</md-button>
+    </a>
   </div>
+
    <div ng-if="respondableGroups.length > 1" class="group-select">
     <label>Select Group:</label>
     <md-select ng-model="state.groupIndex">


### PR DESCRIPTION
This is a preliminary version of paging. There is paging on the admin tab and the invited tab but all joined experiments are loaded without limits or paging. Note also that all 3 tabs are loaded up front though we probably want to only load when a tab is first loaded. For now, I show all invites in a page but gray out the join button since we've loaded the joined list and know which ones are already joined. We need to display all of them, even the joined ones, however, or the user may press Show More and get back less than the expected number of results. There's at least one side-effect of the paging. If the user has loaded a second or more pages of the admin list, then deletes an experiment, the list is reloaded but only the first page. Seems like a minor, non-fatal edge-case.