### PR TITLE
Fixed issues #1234 and #1235

### DIFF
--- a/Paco/src/com/pacoapp/paco/triggering/NotificationCreator.java
+++ b/Paco/src/com/pacoapp/paco/triggering/NotificationCreator.java
@@ -395,7 +395,7 @@ public class NotificationCreator {
                                                                                             .setWhen(notificationHolder.getAlarmTime())
                                                                                             .setContentIntent(notificationIntent)
                                                                                             .setAutoCancel(dismissible)
-                                                                                            .setColor(color)
+                                                                                            .setLights(color,PacoNotificationAction.DEFAULT_NOTIFICATION_DELAY,PacoNotificationAction.DEFAULT_NOTIFICATION_DELAY)
                                                                                             .setStyle(bigStyle);
 
     int defaults = Notification.DEFAULT_VIBRATE | Notification.DEFAULT_LIGHTS;

--- a/Paco/src/com/pacoapp/paco/triggering/NotificationCreator.java
+++ b/Paco/src/com/pacoapp/paco/triggering/NotificationCreator.java
@@ -394,7 +394,8 @@ public class NotificationCreator {
                                                                                             .setContentText(message)
                                                                                             .setWhen(notificationHolder.getAlarmTime())
                                                                                             .setContentIntent(notificationIntent)
-                                                                                            .setAutoCancel(dismissible)
+                                                                                            .setOngoing(!dismissible) //whether it's dismissible
+                                                                                            .setAutoCancel(dismissible) //whether it should disappear on user click
                                                                                             .setLights(color,PacoNotificationAction.DEFAULT_NOTIFICATION_DELAY,PacoNotificationAction.DEFAULT_NOTIFICATION_DELAY)
                                                                                             .setStyle(bigStyle);
 


### PR DESCRIPTION
We used the wrong functions for custom LED color (Issue #1234) and non-dismissible notifications (Issue #1235).

<i><b>Previous:</b></i>
<b>setColor</b>: changes the icon color
<b>setAutoCancel</b>: makes the notification disappear as soon as the user clicks on it (doesn't prevent dismissing)

<i><b>Current:</b></i>
<b>setLights</b>: sets the LED color this time. Can also specify time between light flashes - used the default notification delay from PacoNotificationAction. (making it editable would possibly over-complicate things).
<b>setOngoing</b>: Makes the notification non-dismissible (if true), and also whenever this is true, <b>setAutoCancel</b> is false, to only make it disappear when the user saves.

