### PR TITLE
Android: Added support for pacoapp://experiment/123456

### DIFF
--- a/Paco/AndroidManifest.xml
+++ b/Paco/AndroidManifest.xml
@@ -84,6 +84,12 @@
 
                 <data android:mimeType="vnd.android.cursor.dir/vnd.google.paco.experiment" />
             </intent-filter>
+            <intent-filter>
+                <data android:scheme="pacoapp" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.intent.action.BROWSABLE" />
+            </intent-filter>
         </activity>
         
         <activity

--- a/Paco/res/values/strings.xml
+++ b/Paco/res/values/strings.xml
@@ -132,6 +132,7 @@
     <string name="experiment_refresh">Experiment Refresh</string>
     <string name="checking_server_for_new_and_updated_experiment_definitions">Checking Server for New and Updated Experiment Definitions</string>
     <string name="selected_experiment_not_on_phone_refresh">Selected Experiment does not exist on the phone. Refresh Experiments from Server?</string>
+    <string name="link_wrong">Make sure you are using the right link.</string>
     <string name="ongoing_duration">ongoing</string>
     <string name="day_esm_period">Day</string>
     <string name="week_esm_period">Week</string>


### PR DESCRIPTION
This should do the trick!

After browsing through the code, it looks like most of the "error handling" (experiment not on device yet, no network, etc) is already implemented, so there shouldn't be any issues.

Also, <i>action.BROWSABLE</i> in the intent-filter allows browsers to ask to run those links in Paco.

We need to remember to add an option in the Web UI (and possibly mobile app) to give the links.

=

( Refers to issue #1248 )
