### PR TITLE
Gulp

### DIFF
--- a/Paco-Server/ear/default/web/gulp.html
+++ b/Paco-Server/ear/default/web/gulp.html
@@ -6,8 +6,12 @@
   <link rel="stylesheet" href="css/styles.min.css">
 </head>
 
-<body>
-  <div ng-view id="body"></div>
+<body ng-app="pacoApp" ng-controller="HomeCtrl">
+  <div class="home">
+    <div ng-include="'partials/menu.html'"></div>
+    <div ng-view class="main"></div>
+    <div ng-include="'partials/sitemap.html'"></div>
+  </div>
 </body>
 
 </html>

--- a/Paco-Server/ear/default/web/js/services.js
+++ b/Paco-Server/ear/default/web/js/services.js
@@ -349,7 +349,7 @@ pacoApp.service('config', function() {
     'when'
   ];
 
-  this.helpLinkBase = 'https://docs.google.com/a/google.com/document/d/1f_kkTtvb4TKWIoseYfbOuX6D-8TOiZ3pIkjJ_sI6eGM/pub?embedded=true';
+  this.helpLinkBase = 'https://docs.google.com/a/google.com/document/d/1o81ps90gGT3SYEKS1meHfqee-A8c65-Jailz3A1Uwmg/pub?embedded=true';
 
   this.helpLinks = {
     'advanced': 'h.le5i22y0oxrv',

--- a/Paco-Server/gulpfile.js
+++ b/Paco-Server/gulpfile.js
@@ -1,10 +1,11 @@
 /* Installation
- * 
+ *
  * The following will install the necessary npm modules for this gulpfile:
- 
+ *
+
  % npm install gulp gulp-ruby-sass gulp-autoprefixer gulp-minify-css \
     gulp-jshint gulp-concat gulp-uglify gulp-imagemin gulp-notify gulp-rename \
-    del gulp-util gulp-html-replace --save-dev
+    del gulp-util gulp-html-replace es6-promise --save-dev
 
  *
  */
@@ -23,6 +24,8 @@ var notify = require('gulp-notify');
 var htmlreplace = require('gulp-html-replace');
 var del = require('del');
 
+var Promise = require('es6-promise').Promise;
+
 // Source path
 var srcPath = 'ear/default/web/';
 
@@ -33,7 +36,7 @@ var distPath = 'build/default/web/';
 // Styles
 gulp.task('styles', function() {
   return gulp.src([srcPath + 'bower_components/angular/angular-csp.css', srcPath + 'bower_components/angular-material/angular-material.css', srcPath + 'bower_components/angular-material/default-theme.css', srcPath + 'css/*.css'])
-    .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1', 'ios 6', 'android 4'))
+    .pipe(autoprefixer({browsers: ['last 2 versions'], cascade: false}))
     .pipe(concat('styles.css'))
     .pipe(gulp.dest(distPath + 'css'))
     .pipe(rename({
@@ -123,6 +126,6 @@ gulp.task('clean', function(cb) {
 
 
 // Default task
-gulp.task('default', ['clean'], function() {
+gulp.task('default', [], function() {
   gulp.start('styles', 'scripts', 'ng-scripts', 'images', 'partials', 'favicon', 'index');
 });


### PR DESCRIPTION
The error was related to autoprefixer and this thread provided a simple fix. http://stackoverflow.com/questions/32490328/gulp-autoprefixer-throwing-referenceerror-promise-is-not-defined

Sounds like doing a clean reinstall of certain modules may also solve the problem but I didn't want to spend to much time on this.

In addition, the gulp.html was quite out of date and didn't have the necessary top-level structure for all of the Angular app to appear.

This also fixes the Google doc hyperlink, which was the original reason for this change.
