### PR TITLE
Fixes typo in help file: dat handling policy -> data handling policy

### DIFF
--- a/Paco-Server/ear/default/web/eod/help.html
+++ b/Paco-Server/ear/default/web/eod/help.html
@@ -35,7 +35,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco-Server/ear/default/web/eod/help_fi.html
+++ b/Paco-Server/ear/default/web/eod/help_fi.html
@@ -35,7 +35,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco-Server/ear/default/web/eod/help_ja.html
+++ b/Paco-Server/ear/default/web/eod/help_ja.html
@@ -36,7 +36,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco-iOS/Paco/resources/help.html
+++ b/Paco-iOS/Paco/resources/help.html
@@ -35,7 +35,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco/assets/help.html
+++ b/Paco/assets/help.html
@@ -35,7 +35,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco/assets/help_fi.html
+++ b/Paco/assets/help_fi.html
@@ -35,7 +35,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  

--- a/Paco/assets/help_ja.html
+++ b/Paco/assets/help_ja.html
@@ -36,7 +36,7 @@
     When you see one that looks interesting, click on it to see the description, who created it, and the sampling schedule.</p>
     <p>If you think you might want to join that experiment, click "Join". This will take you to a page to see the data handling policy of the experiment creator.<br/>
     <b>Note: Only join experiments where you are satisfied with how the data will be handled.</b></p>
-    <p>If you decide you feel comfortable with the experiment's dat handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
+    <p>If you decide you feel comfortable with the experiment's data handling policy, then click the informed consent checkbox. Next you will be taken to the schedule settings for the experiment. 
     Usually you want to keep the default schedule, but perhaps you may need to slightly alter the times to suit your routine better.
     Press "Save Schedule" to complete the joining process.</p>
     <p>If you decide you don't want to join, just press the back button until you are back to the experiment list or the main page.<p>  


### PR DESCRIPTION
Fixes across all help*.html files.

I signed the Google Contributor License Agreement