### PR TITLE
Adding calendar.listEventInstances method.

### DIFF
--- a/Paco/AndroidManifest.xml
+++ b/Paco/AndroidManifest.xml
@@ -333,8 +333,9 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.GET_TASKS"/>
     <uses-permission android:name="com.android.browser.permission.READ_HISTORY_BOOKMARKS" />
-     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
     <uses-sdk android:minSdkVersion="11"  android:targetSdkVersion="22"></uses-sdk>

--- a/Paco/src/com/pacoapp/paco/js/bridge/JavascriptCalendarManager.java
+++ b/Paco/src/com/pacoapp/paco/js/bridge/JavascriptCalendarManager.java
@@ -1,0 +1,84 @@
+package com.pacoapp.paco.js.bridge;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.CalendarContract.Calendars;
+import android.provider.CalendarContract.Instances;
+import android.provider.CalendarContract.Events;
+import android.webkit.JavascriptInterface;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.pacoapp.paco.sensors.android.AndroidInstalledApplications;
+import com.pacoapp.paco.shared.model2.JsonConverter;
+
+public class JavascriptCalendarManager {
+
+  private static final String[] INSTANCE_PROJECTION = new String[] {
+    Events._SYNC_ID,
+    Instances.TITLE,
+    Instances.BEGIN,
+    Instances.END,
+    Calendars.CALENDAR_DISPLAY_NAME
+  };
+
+  private final Context context;
+
+  public JavascriptCalendarManager(Context context) {
+    this.context = context;
+  }
+
+  /**
+   * get a list of all the calendar event list within the given time range.
+   */
+  @JavascriptInterface
+  public String listEventInstances(String startMillis, String endMillis)
+      throws NumberFormatException {
+    Cursor cursor = null;
+    ContentResolver cr = context.getContentResolver();
+
+    // Create a cursor for the query.
+    Uri.Builder builder = Instances.CONTENT_URI.buildUpon();
+    ContentUris.appendId(builder, Long.parseLong(startMillis));
+    ContentUris.appendId(builder, Long.parseLong(endMillis));
+    cursor =  cr.query(builder.build(), INSTANCE_PROJECTION, null, null, null);
+
+    // Add the events from the cursor to a JSON-friendly blob.
+    final List<Map<String, Object>> eventList = new ArrayList<Map<String, Object>>();
+    while (cursor.moveToNext()) {
+        Map<String, Object> event = new HashMap<String, Object>();
+        event.put("id", cursor.getString(cursor.getColumnIndexOrThrow(Events._SYNC_ID)));
+        event.put("title", cursor.getString(cursor.getColumnIndexOrThrow(Instances.TITLE)));
+        event.put("begin", cursor.getString(cursor.getColumnIndexOrThrow(Instances.BEGIN)));
+        event.put("end", cursor.getString(cursor.getColumnIndexOrThrow(Instances.END)));
+        event.put("calendarDisplayName",
+            cursor.getString(cursor.getColumnIndexOrThrow(Calendars.CALENDAR_DISPLAY_NAME)));
+        eventList.add(event);
+     }
+
+    ObjectMapper mapper = JsonConverter.getObjectMapper();
+    String json = null;
+    try {
+      json = mapper.writeValueAsString(eventList);
+    } catch (JsonGenerationException e) {
+      e.printStackTrace();
+    } catch (JsonMappingException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return json;
+  }
+
+}

--- a/Paco/src/com/pacoapp/paco/ui/ExperimentExecutorCustomRendering.java
+++ b/Paco/src/com/pacoapp/paco/ui/ExperimentExecutorCustomRendering.java
@@ -85,6 +85,7 @@ import com.google.common.base.Strings;
 import com.pacoapp.paco.PacoConstants;
 import com.pacoapp.paco.R;
 import com.pacoapp.paco.js.bridge.Environment;
+import com.pacoapp.paco.js.bridge.JavascriptCalendarManager;
 import com.pacoapp.paco.js.bridge.JavascriptEmail;
 import com.pacoapp.paco.js.bridge.JavascriptEventLoader;
 import com.pacoapp.paco.js.bridge.JavascriptExperimentLoader;
@@ -475,6 +476,7 @@ private void injectObjectsIntoJavascriptEnvironment() {
   // deprecated name - use "db" in all new experiments
   webView.addJavascriptInterface(javascriptEventLoader, "eventLoader");
 
+  webView.addJavascriptInterface(new JavascriptCalendarManager(this), "calendar");
   webView.addJavascriptInterface(new JavascriptEmail(this), "email");
   webView.addJavascriptInterface(new JavascriptNotificationService(this, experiment.getExperimentDAO(), experimentGroup), "notificationService");
   webView.addJavascriptInterface(new JavascriptPhotoService(this), "photoService");


### PR DESCRIPTION
The new calendar.listEventInstances(startDateTime, endDateTime) function uses
the Android calendar content provider to return upcoming events.

This returns an array of events objects with the following properties:
  "id" - The calendar instance event ID as it appears in the Calendar v3 API.
  "title" - The event title.
  "begin" - The timestamp of the event start.
  "end" - The timestamp of the event end.
  "calendarDisplayName" - The name of the calendar.

Note that this requires the additional calendar premission.