### PR TITLE
Add Javascript methods for querying permissions granted to packages

### DIFF
--- a/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
+++ b/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
@@ -29,35 +29,32 @@ public class JavascriptPackageManager {
   @JavascriptInterface
   public String getNamesOfInstalledApplications() {
     final List<String> namesOfInstalledApplications = new AndroidInstalledApplications(context).getNamesOfInstalledApplications();
-    ObjectMapper mapper = JsonConverter.getObjectMapper();
-    String json = null;
-    try {
-      json = mapper.writeValueAsString(namesOfInstalledApplications);
-    } catch (JsonGenerationException e) {
-
-      e.printStackTrace();
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return json;
+    return convertToJsonString(namesOfInstalledApplications);
   }
 
   /**
    * Get a list of all applications, and the permissions that were granted to them. For packages
    * targeting SDK version 21 or lower, this means "permissions requested at install time"; for
    * packages targeting SDK 22 or newer, this means "permissions granted during runtime".
+   * TODO: write similar function for getting app name from package (or include the name here)
    * @return A JSON string of the format {[packageName1: [permission1, permission2]]}
    */
   @JavascriptInterface
   public String getGrantedPermissions() {
     final Map<String, List<String>> grantedPermissions = new AndroidInstalledApplications(context).getGrantedPermissions();
-    // TODO: extract method for both of these JS functions
+    return convertToJsonString(grantedPermissions);
+  }
+
+  /**
+   * Helper function that converts any object to a JSON string
+   * @param object The object we want to convert
+   * @return A string containing a JSON representation of the object
+   */
+  private String convertToJsonString(Object object) {
     ObjectMapper mapper = JsonConverter.getObjectMapper();
     String json = null;
     try {
-      json = mapper.writeValueAsString(grantedPermissions);
+      json = mapper.writeValueAsString(object);
     } catch (JsonGenerationException e) {
       e.printStackTrace();
     } catch (JsonMappingException e) {

--- a/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
+++ b/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
@@ -2,6 +2,7 @@ package com.pacoapp.paco.js.bridge;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
@@ -34,6 +35,30 @@ public class JavascriptPackageManager {
       json = mapper.writeValueAsString(namesOfInstalledApplications);
     } catch (JsonGenerationException e) {
 
+      e.printStackTrace();
+    } catch (JsonMappingException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return json;
+  }
+
+  /**
+   * Get a list of all applications, and the permissions that were granted to them. For packages
+   * targeting SDK version 21 or lower, this means "permissions requested at install time"; for
+   * packages targeting SDK 22 or newer, this means "permissions granted during runtime".
+   * @return A JSON string of the format {[packageName1: [permission1, permission2]]}
+   */
+  @JavascriptInterface
+  public String getGrantedPermissions() {
+    final Map<String, List<String>> grantedPermissions = new AndroidInstalledApplications(context).getGrantedPermissions();
+    // TODO: extract method for both of these JS functions
+    ObjectMapper mapper = JsonConverter.getObjectMapper();
+    String json = null;
+    try {
+      json = mapper.writeValueAsString(grantedPermissions);
+    } catch (JsonGenerationException e) {
       e.printStackTrace();
     } catch (JsonMappingException e) {
       e.printStackTrace();

--- a/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
+++ b/Paco/src/com/pacoapp/paco/js/bridge/JavascriptPackageManager.java
@@ -33,10 +33,19 @@ public class JavascriptPackageManager {
   }
 
   /**
+   * Resolves an Android package name to the name of the app, if it is visible to the user.
+   * @param packageName The package name of the application
+   * @return The application name, or an empty string if the package was not found
+   */
+  @JavascriptInterface
+  public String getApplicationName(String packageName) {
+    return new AndroidInstalledApplications(context).getApplicationName(packageName);
+  }
+
+  /**
    * Get a list of all applications, and the permissions that were granted to them. For packages
    * targeting SDK version 21 or lower, this means "permissions requested at install time"; for
    * packages targeting SDK 22 or newer, this means "permissions granted during runtime".
-   * TODO: write similar function for getting app name from package (or include the name here)
    * @return A JSON string of the format {[packageName1: [permission1, permission2]]}
    */
   @JavascriptInterface

--- a/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
@@ -1,12 +1,17 @@
 package com.pacoapp.paco.sensors.android;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.Log;
 
 import com.google.common.collect.Lists;
@@ -50,6 +55,35 @@ public class AndroidInstalledApplications {
     }
     Collections.sort(appNames);
     return appNames;
+  }
+
+  /**
+   * Get a list of all applications, and the permissions that were granted to them. For packages
+   * targeting SDK version 21 or lower, this means "permissions requested at install time"; for
+   * packages targeting SDK 22 or newer, this means "permissions granted during runtime".
+   * @return A map with the names of installed packages as keys, and a list of the granted
+   *         permissions as values
+   */
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  public Map<String, List<String>> getGrantedPermissions() {
+    PackageManager packageManager = context.getPackageManager();
+    List<PackageInfo> installedPackages = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS);
+
+    Map<String, List<String>> result = new HashMap();
+    for (PackageInfo packageInfo : installedPackages) {
+      List<String> grantedPermissions = new ArrayList();
+      // Traverse list of requested permissions for package
+      for (int i = 0; i < packageInfo.requestedPermissions.length; i++) {
+        // Check if permission was granted (in case of pre-Marshmallow apps: if permission was
+        // requested at install time.
+        if ((packageInfo.requestedPermissionsFlags[i] & PackageInfo.REQUESTED_PERMISSION_GRANTED) != 0) {
+          grantedPermissions.add(packageInfo.requestedPermissions[i]);
+        }
+      }
+      result.put(packageInfo.packageName, grantedPermissions);
+    }
+
+    return result;
   }
 
 

--- a/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
@@ -58,6 +58,25 @@ public class AndroidInstalledApplications {
   }
 
   /**
+   * Resolves an Android package name to the name of the app, if it is visible to the user.
+   * @param packageName The package name of the application
+   * @return The application name, or an empty string if the package was not found
+   */
+  public String getApplicationName(String packageName) {
+    PackageManager packageManager = context.getPackageManager();
+    try {
+      ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
+      if (applicationInfo == null) {
+        return "";
+      }
+      return applicationInfo.loadLabel(packageManager).toString();
+    } catch (PackageManager.NameNotFoundException e) {
+      Log.w(PacoConstants.TAG, "No app name found for package " + packageName);
+      return "";
+    }
+  }
+
+  /**
    * Get a list of all applications, and the permissions that were granted to them. For packages
    * targeting SDK version 21 or lower, this means "permissions requested at install time"; for
    * packages targeting SDK 22 or newer, this means "permissions granted during runtime".

--- a/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/AndroidInstalledApplications.java
@@ -71,6 +71,10 @@ public class AndroidInstalledApplications {
 
     Map<String, List<String>> result = new HashMap();
     for (PackageInfo packageInfo : installedPackages) {
+      if (packageInfo.requestedPermissions == null) {
+        // This package didn't request any permissions
+        continue;
+      }
       List<String> grantedPermissions = new ArrayList();
       // Traverse list of requested permissions for package
       for (int i = 0; i < packageInfo.requestedPermissions.length; i++) {


### PR DESCRIPTION
Two methods added to the `packagemanager` Javascript interface:

`getApplicationName(String packageName)`
Resolves an Android package name to the name of the app, if it is visible to the user.

`getGrantedPermissions()`
Get a list of all applications, and the permissions that were granted to them. For packages targeting SDK version 21 or lower, this means "permissions requested at install time"; for packages targeting SDK 22 or newer, this means "permissions granted during runtime".