### PR TITLE
Fix Android N inconsistency in AccessibilityService

### DIFF
--- a/Paco/src/com/pacoapp/paco/sensors/android/RuntimePermissionMonitorService.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/RuntimePermissionMonitorService.java
@@ -173,7 +173,7 @@ public class RuntimePermissionMonitorService extends AccessibilityService {
           Log.v(PacoConstants.TAG, "Action taken in permission settings activity");
           processPermissionConfigurationChange(accessibilityEvent);
         } else {
-          Log.v(PacoConstants.TAG, "Ignoring content change type subtree, since it was not in a permission dialog or a settings screen.");
+          Log.v(PacoConstants.TAG, "Ignoring TYPE_VIEW_CLICKED, since it was not in a permission dialog or a settings screen.");
         }
         break;
     }

--- a/Paco/src/com/pacoapp/paco/sensors/android/RuntimePermissionMonitorService.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/RuntimePermissionMonitorService.java
@@ -163,7 +163,7 @@ public class RuntimePermissionMonitorService extends AccessibilityService {
         Log.v(PacoConstants.TAG, "This might be a changed permissions dialog, try to extract info");
         extractInformationFromEventText(accessibilityEvent.getText());
         break;
-      case AccessibilityEvent.CONTENT_CHANGE_TYPE_SUBTREE:
+      case AccessibilityEvent.TYPE_VIEW_CLICKED:
         // For our purposes, this means: permission change via switch button (in settings),
         // or clicking 'allow/deny' in a runtime permission dialog
         if (isPermissionsDialogAction(accessibilityEvent.getSource())) {
@@ -395,7 +395,17 @@ public class RuntimePermissionMonitorService extends AccessibilityService {
       // Will also resolve package names
       setCurrentlyHandledAppName(switchName);
     }
-    boolean isAllowed = textFields.get(1).equals("ON");
+    // Get the switch button, and check whether it is enabled
+    AccessibilityNodeInfo source = accessibilityEvent.getSource();
+    List<AccessibilityNodeInfo> switchButtons = source.findAccessibilityNodeInfosByViewId("com.android.packageinstaller:id/switchWidget");
+    if (switchButtons.size() == 0) {
+      switchButtons = source.findAccessibilityNodeInfosByViewId("android:id/switch_widget");
+    }
+    if (switchButtons.size() == 0) {
+      Log.e(PacoConstants.TAG, "We couldn't find the switch button in the permissions activity!");
+      return;
+    }
+    boolean isAllowed = switchButtons.get(0).isChecked();
     triggerBroadcastTriggerService(isAllowed, true);
   }
 


### PR DESCRIPTION
The behavior of the `getText()` method was different for the packageinstaller in Android M and Android N. This new approach uses the `isChecked()` method on the actual switch instead to get a more consistent response.