### PR TITLE
Add end-to-end encryption functionality to Paco

### DIFF
--- a/Paco-Server/ear/default/web/partials/admin.html
+++ b/Paco-Server/ear/default/web/partials/admin.html
@@ -86,5 +86,13 @@
         <textarea ng-model="experiment.informedConsentForm"></textarea>
       </md-input-container>
 
+      <md-input-container layout-margin>
+        <label>RSA Public key</label>
+        <textarea ng-model="experiment.publicKey"></textarea>
+        <div ng-messages>
+          <div ng-message>Leave empty for no end-to-end encryption.</div>
+        </div>
+      </md-input-container>
+
   </md-card-content>
 </md-card>

--- a/Paco-Server/src/com/google/sampling/experiential/server/DAOConverterOld.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/DAOConverterOld.java
@@ -51,6 +51,7 @@ public class DAOConverterOld {
     String description = experiment.getDescription();
     String informedConsentForm = experiment.getInformedConsentFormText();
     String email = experiment.getCreator().getEmail();
+    String publicKey = null;
 
     Boolean published = experiment.getPublished();
 
@@ -105,7 +106,7 @@ public class DAOConverterOld {
       List<Integer> jdoDetachedList = Lists.newArrayList(extraDataCollectionDeclarations);
       extraDataCollectionDeclarations = jdoDetachedList;
     }
-    ExperimentDAO dao = new ExperimentDAO(id, title, description, informedConsentForm, email, signalingMechanisms,
+    ExperimentDAO dao = new ExperimentDAO(id, title, description, informedConsentForm, email, publicKey, signalingMechanisms,
                                           fixedDuration, questionsChange, startDate, endDate, hash, joinDate,
                                           modifyDate, published, adminStrArray, userEmailsStrArray, deleted, null,
                                           version, experiment.isCustomRendering(), customRenderingCode, feedbackType,

--- a/Paco/src/com/pacoapp/paco/net/Crypto.java
+++ b/Paco/src/com/pacoapp/paco/net/Crypto.java
@@ -37,6 +37,9 @@ import javax.crypto.spec.IvParameterSpec;
  */
 
 public class Crypto {
+  public static final String ENCRYPTION_KEY = "encryptionKey";
+  public static final String ENCRYPTION_IV = "encryptionIv";
+
   private ExperimentProviderUtil experimentProviderUtil;
 
   /**
@@ -117,14 +120,14 @@ public class Crypto {
   private void addKeyResponses(List<Output> responses, SecretKey secretKey, IvParameterSpec iv, PublicKey publicKey) throws IllegalBlockSizeException, InvalidKeyException, BadPaddingException, NoSuchAlgorithmException, NoSuchPaddingException {
     // Add the symmetric key as a response, encrypted with the public key of the experiment organizer
     Output keyResponse = new Output();
-    keyResponse.setName("encryptionKey");
+    keyResponse.setName(ENCRYPTION_KEY);
     byte[] secretKeyBytes = secretKey.getEncoded();
     keyResponse.setAnswer(encryptWithPublic(secretKeyBytes, publicKey));
     responses.add(keyResponse);
 
     // Add the IV
     Output ivResponse = new Output();
-    ivResponse.setName("encryptionIv");
+    ivResponse.setName(ENCRYPTION_IV);
     byte[] ivBytes = iv.getIV();
     ivResponse.setAnswer(encryptWithPublic(ivBytes, publicKey));
     responses.add(ivResponse);

--- a/Paco/src/com/pacoapp/paco/net/Crypto.java
+++ b/Paco/src/com/pacoapp/paco/net/Crypto.java
@@ -1,0 +1,95 @@
+package com.pacoapp.paco.net;
+
+import android.content.Context;
+import android.util.Base64;
+import android.util.Log;
+
+import com.pacoapp.paco.PacoConstants;
+import com.pacoapp.paco.model.Event;
+import com.pacoapp.paco.model.Experiment;
+import com.pacoapp.paco.model.ExperimentProviderUtil;
+import com.pacoapp.paco.model.Output;
+
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public class Crypto {
+  private ExperimentProviderUtil experimentProviderUtil;
+
+  public Crypto(Context context) {
+    experimentProviderUtil = new ExperimentProviderUtil(context);
+  }
+
+  public List<Event> encryptAnswers(List<Event> events) throws NoSuchAlgorithmException, NoSuchPaddingException {
+    ArrayList<Event> encryptedEvents = new ArrayList();
+    for (Event event : events) {
+      encryptedEvents.add(encryptAnswers(event));
+    }
+    return encryptedEvents;
+  }
+
+  public Event encryptAnswers(Event event) throws NoSuchPaddingException, NoSuchAlgorithmException {
+    long experimentId = event.getExperimentServerId();
+    Experiment experiment = experimentProviderUtil.getExperimentByServerId(experimentId);
+    String publicKeyString = experiment.getExperimentDAO().getPublicKey();
+    if (publicKeyString == "") {
+      Log.v(PacoConstants.TAG, "No public key for experiment " + experiment.getExperimentDAO().getTitle());
+      return event;
+    }
+
+    Log.v(PacoConstants.TAG, "Using public key for experiment " + experiment.getExperimentDAO().getTitle() + ". Key string is " + publicKeyString);
+    PublicKey publicKey = base64ToPublicKey(publicKeyString);
+
+    ArrayList<Output> encryptedResponses = new ArrayList();
+    for (Output answer : event.getResponses()) {
+      encryptedResponses.add(encryptAnswer(answer, publicKey));
+    }
+    event.setResponses(encryptedResponses);
+
+    return event;
+  }
+
+  private Output encryptAnswer(Output response, PublicKey publicKey) throws NoSuchPaddingException, NoSuchAlgorithmException {
+    Cipher cipher = Cipher.getInstance("RSA");
+    try {
+      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+      String answer = response.getAnswer();
+      String encryptedAnswer = cipher.doFinal(answer.getBytes()).toString();
+      response.setAnswer(encryptedAnswer);
+    } catch (InvalidKeyException e) {
+      // TODO: inform the experiment organizer about the key being invalid
+      Log.e(PacoConstants.TAG, "Invalid key for experiment " + e);
+      // Return unencrypted
+    } catch (BadPaddingException e) {
+      Log.e(PacoConstants.TAG, "Bad padding for answer " + e);
+    } catch (IllegalBlockSizeException e) {
+      Log.e(PacoConstants.TAG, "Illegal block size for answer " + e);
+    }
+    return response;
+  }
+
+  private PublicKey base64ToPublicKey(String publicKeyString) {
+    try{
+      byte[] byteKey = Base64.decode(publicKeyString.getBytes(), Base64.DEFAULT);
+      X509EncodedKeySpec X509publicKey = new X509EncodedKeySpec(byteKey);
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+
+      return kf.generatePublic(X509publicKey);
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+
+    return null;
+  }
+}

--- a/Paco/src/com/pacoapp/paco/net/Crypto.java
+++ b/Paco/src/com/pacoapp/paco/net/Crypto.java
@@ -23,13 +23,31 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
+/**
+ * This class provides all end-to-end crypto functionality in Paco. It allows an experiment provider
+ * to store all data on the server encrypted with their own public RSA key, so we are not able to
+ * read the data.
+ */
+
 public class Crypto {
   private ExperimentProviderUtil experimentProviderUtil;
 
+  /**
+   * Constructor
+   * @param context The application context
+   */
   public Crypto(Context context) {
     experimentProviderUtil = new ExperimentProviderUtil(context);
   }
 
+  /**
+   * Encrypt all answers for the responses given in the event lists. Every event's Experiment is
+   * checked to see whether it provides a public key. If so, the answers for the event are encrypted
+   * @param events The events we would like to encrypt
+   * @return The same events as were passed to the function
+   * @throws NoSuchAlgorithmException If the RSA algorithm is not supported on the device
+   * @throws NoSuchPaddingException If padding is not supported for RSA on the device
+   */
   public List<Event> encryptAnswers(List<Event> events) throws NoSuchAlgorithmException, NoSuchPaddingException {
     ArrayList<Event> encryptedEvents = new ArrayList();
     for (Event event : events) {
@@ -38,6 +56,14 @@ public class Crypto {
     return encryptedEvents;
   }
 
+  /**
+   * Encrypt all answers for the responses in an event, if the event belongs to an experiment that
+   * provides a public key. If there is no key for an experiment, the answers are left unencrypted.
+   * @param event The event we would like to encrypt
+   * @return The same event as was passed to the function
+   * @throws NoSuchAlgorithmException If the RSA algorithm is not supported on the device
+   * @throws NoSuchPaddingException If padding is not supported for RSA on the device
+   */
   public Event encryptAnswers(Event event) throws NoSuchPaddingException, NoSuchAlgorithmException {
     long experimentId = event.getExperimentServerId();
     Experiment experiment = experimentProviderUtil.getExperimentByServerId(experimentId);
@@ -59,6 +85,14 @@ public class Crypto {
     return event;
   }
 
+  /**
+   * Encrypt a single response's answer using the provided public key
+   * @param response The response for which to encrypt the answer
+   * @param publicKey The corresponding experiment's public key
+   * @return The same response as was passed to the function
+   * @throws NoSuchPaddingException
+   * @throws NoSuchAlgorithmException
+   */
   private Output encryptAnswer(Output response, PublicKey publicKey) throws NoSuchPaddingException, NoSuchAlgorithmException {
     Cipher cipher = Cipher.getInstance("RSA");
     try {
@@ -78,6 +112,11 @@ public class Crypto {
     return response;
   }
 
+  /**
+   * Converts a provided BASE64 encoded public key to the corresponding RSA key
+   * @param publicKeyString A BASE64 encoded public key
+   * @return A RSA Public Key
+   */
   private PublicKey base64ToPublicKey(String publicKeyString) {
     try{
       byte[] byteKey = Base64.decode(publicKeyString.getBytes(), Base64.DEFAULT);

--- a/Paco/src/com/pacoapp/paco/net/Crypto.java
+++ b/Paco/src/com/pacoapp/paco/net/Crypto.java
@@ -41,10 +41,10 @@ public class Crypto {
 
   /**
    * Constructor
-   * @param context The application context
+   * @param experimentProviderUtil An experimentProviderUtil initialized with the current app context
    */
-  public Crypto(Context context) {
-    experimentProviderUtil = new ExperimentProviderUtil(context);
+  public Crypto(ExperimentProviderUtil experimentProviderUtil) {
+    this.experimentProviderUtil = experimentProviderUtil;
   }
 
   /**
@@ -124,9 +124,10 @@ public class Crypto {
 
     // Add the IV
     Output ivResponse = new Output();
-    keyResponse.setName("encryptionIv");
+    ivResponse.setName("encryptionIv");
     byte[] ivBytes = iv.getIV();
-    keyResponse.setAnswer(encryptWithPublic(ivBytes, publicKey));
+    ivResponse.setAnswer(encryptWithPublic(ivBytes, publicKey));
+    responses.add(ivResponse);
   }
 
   /**

--- a/Paco/src/com/pacoapp/paco/net/SyncService.java
+++ b/Paco/src/com/pacoapp/paco/net/SyncService.java
@@ -85,6 +85,8 @@ public class SyncService extends Service {
       EventUploader eventUploader = new EventUploader(this, userPrefs.getServerAddress(),
                         experimentProviderUtil);
       try {
+        // For all events, check whether they belong to an experiment that provides a key, and
+        // encrypt their answers accordingly
         List<Event> encryptedEvents = new Crypto(this.getApplicationContext()).encryptAnswers(allEvents);
         eventUploader.uploadEvents(encryptedEvents);
       } catch (NoSuchAlgorithmException e) {

--- a/Paco/src/com/pacoapp/paco/net/SyncService.java
+++ b/Paco/src/com/pacoapp/paco/net/SyncService.java
@@ -86,7 +86,7 @@ public class SyncService extends Service {
                         experimentProviderUtil);
       // For all events, check whether they belong to an experiment that provides a key, and
       // encrypt their answers accordingly
-      List<Event> encryptedEvents = new Crypto(this.getApplicationContext()).encryptAnswers(allEvents);
+      List<Event> encryptedEvents = new Crypto(experimentProviderUtil).encryptAnswers(allEvents);
       eventUploader.uploadEvents(encryptedEvents);
     }
   }

--- a/Paco/src/com/pacoapp/paco/net/SyncService.java
+++ b/Paco/src/com/pacoapp/paco/net/SyncService.java
@@ -84,18 +84,10 @@ public class SyncService extends Service {
       List<Event> allEvents = experimentProviderUtil.getEventsNeedingUpload();
       EventUploader eventUploader = new EventUploader(this, userPrefs.getServerAddress(),
                         experimentProviderUtil);
-      try {
-        // For all events, check whether they belong to an experiment that provides a key, and
-        // encrypt their answers accordingly
-        List<Event> encryptedEvents = new Crypto(this.getApplicationContext()).encryptAnswers(allEvents);
-        eventUploader.uploadEvents(encryptedEvents);
-      } catch (NoSuchAlgorithmException e) {
-        Log.e(PacoConstants.TAG, "Crypto algorithm not supported!" + e);
-        eventUploader.uploadEvents(allEvents);
-      } catch (NoSuchPaddingException e) {
-        Log.e(PacoConstants.TAG, "Padding not supported!" + e);
-        eventUploader.uploadEvents(allEvents);
-      }
+      // For all events, check whether they belong to an experiment that provides a key, and
+      // encrypt their answers accordingly
+      List<Event> encryptedEvents = new Crypto(this.getApplicationContext()).encryptAnswers(allEvents);
+      eventUploader.uploadEvents(encryptedEvents);
     }
   }
 }

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -126,9 +126,9 @@ public class CryptoTest extends AndroidTestCase {
     String encryptionIvEncrypted = null;
     String answerEncrypted = null;
     for (Output response: encryptedEvent.getResponses()) {
-      if (response.getName().equals("encryptionKey"))
+      if (response.getName().equals(Crypto.ENCRYPTION_KEY))
         encryptionKeyEncrypted = response.getAnswer();
-      else if (response.getName().equals("encryptionIv"))
+      else if (response.getName().equals(Crypto.ENCRYPTION_IV))
         encryptionIvEncrypted = response.getAnswer();
       else if (response.getName().equals("name"))
         answerEncrypted = response.getAnswer();

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -183,6 +183,12 @@ public class CryptoTest extends AndroidTestCase {
     }
   }
 
+  /**
+   * Decrypt a byte array using a given private RSA key.
+   * @param encrypted The byte array that was encrypted using the corresponding RSA public key
+   * @param privateKey A private RSA key.
+   * @return The unencrypted byte array.
+   */
   private byte[] decryptAsymmetric(String encrypted, PrivateKey privateKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
     Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
     cipher.init(Cipher.DECRYPT_MODE, privateKey);

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -5,8 +5,11 @@ import android.util.Base64;
 import android.util.Log;
 
 import com.pacoapp.paco.model.Event;
+import com.pacoapp.paco.model.Experiment;
+import com.pacoapp.paco.model.ExperimentProviderUtil;
 import com.pacoapp.paco.model.Output;
 import com.pacoapp.paco.net.Crypto;
+import com.pacoapp.paco.shared.model2.ExperimentDAO;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
@@ -16,16 +19,27 @@ import org.junit.Test;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class CryptoTest extends AndroidTestCase {
   private Crypto crypto;
@@ -33,23 +47,44 @@ public class CryptoTest extends AndroidTestCase {
   private Method encryptAnswer;
   private KeyPair keyPair;
   private Output output;
+  private List<Output> outputList;
+  private ExperimentProviderUtil experimentProviderUtil;
+  private IvParameterSpec ivParameterSpec;
+  private SecretKey secretKey;
 
   @Before
   public void setUp() throws Exception {
-    crypto = new Crypto(getContext());
+    experimentProviderUtil = new MockExperimentProviderUtil(getContext());
+    crypto = new Crypto(experimentProviderUtil);
 
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
     keyGen.initialize(2048);
     keyPair = keyGen.genKeyPair();
+    SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
+    byte[] iv = new byte[16];
+    secureRandom.nextBytes(iv);
+    ivParameterSpec = new IvParameterSpec(iv);
+
+    KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+    keyGenerator.init(192);
+    secretKey = keyGenerator.generateKey();
 
     output = new Output();
     output.setName("name");
     output.setAnswer("answer");
+    outputList = Arrays.asList(output);
+
+    ExperimentDAO dao = new ExperimentDAO();
+    dao.setPublicKey(Base64.encodeToString(keyPair.getPublic().getEncoded(), Base64.NO_WRAP));
+    Experiment experiment = new Experiment();
+    experiment.setExperimentDAO(dao);
+    experiment.setServerId(42L);
+    experimentProviderUtil.insertFullJoinedExperiment(experiment);
 
     // Make necessary methods accessible
     base64ToPublicKey = crypto.getClass().getDeclaredMethod("base64ToPublicKey", String.class);
     base64ToPublicKey.setAccessible(true);
-    encryptAnswer = crypto.getClass().getDeclaredMethod("encryptAnswer", Output.class, PublicKey.class);
+    encryptAnswer = crypto.getClass().getDeclaredMethod("encryptAnswer", Output.class, SecretKey.class, IvParameterSpec.class);
     encryptAnswer.setAccessible(true);
   }
 
@@ -66,42 +101,100 @@ public class CryptoTest extends AndroidTestCase {
   }
 
   @Test
-  public void testEncryptAnswer() throws NoSuchAlgorithmException, InvocationTargetException, IllegalAccessException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+  public void testEncryptAnswer() throws NoSuchAlgorithmException, InvocationTargetException, IllegalAccessException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException, InvalidAlgorithmParameterException {
     Output encryptedOutput = null;
     try {
-      encryptedOutput = (Output) encryptAnswer.invoke(crypto, output, keyPair.getPublic());
+      encryptedOutput = (Output) encryptAnswer.invoke(crypto, output, secretKey, ivParameterSpec);
     } catch (Exception e) {
       fail("Exception when trying to encrypt: " + e);
     }
 
-    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-    cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
-    String encryptedAnswer = encryptedOutput.getAnswer();
-    byte[] encryptedBytes = Base64.decode(encryptedAnswer, Base64.NO_WRAP);
-    byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+    byte[] decryptedBytes = decryptSymmetric(encryptedOutput.getAnswer(), secretKey, ivParameterSpec);
     String decryptedAnswer = new String(decryptedBytes, "UTF-8");
 
     assertEquals(decryptedAnswer, "answer");
   }
 
+  @Test
+  public void testCompleteEncryption() throws NoSuchPaddingException, BadPaddingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IllegalBlockSizeException, UnsupportedEncodingException, InvalidKeyException, InvalidKeySpecException {
+    Event event = new Event();
+    event.setResponses(outputList);
+    event.setServerExperimentId(42L);
+
+    Event encryptedEvent = crypto.encryptAnswers(event);
+    String encryptionKeyEncrypted = null;
+    String encryptionIvEncrypted = null;
+    String answerEncrypted = null;
+    for (Output response: encryptedEvent.getResponses()) {
+      if (response.getName().equals("encryptionKey"))
+        encryptionKeyEncrypted = response.getAnswer();
+      else if (response.getName().equals("encryptionIv"))
+        encryptionIvEncrypted = response.getAnswer();
+      else if (response.getName().equals("name"))
+        answerEncrypted = response.getAnswer();
+    }
+
+    byte[] symmetricKeyBytes = decryptAsymmetric(encryptionKeyEncrypted, keyPair.getPrivate());
+    byte[] ivBytes = decryptAsymmetric(encryptionIvEncrypted, keyPair.getPrivate());
+    SecretKeySpec privKey = new SecretKeySpec(symmetricKeyBytes, "AES");
+    IvParameterSpec ivspec = new IvParameterSpec(ivBytes);
+
+    String decryptedAnswer = new String(decryptSymmetric(answerEncrypted, privKey, ivspec), "UTF-8");
+
+    assertEquals(decryptedAnswer, "answer");
+  }
+
   /**
-   * This test makes sure that encrypting the same string twice would yield a different result. This
-   * is part of non-determinism, which is needed because otherwise someone with access to the server
-   * DB could encrypt a string of plaintext with the public key of the experiment organizer, and
-   * check if the encrypted text corresponds to any data in the database.
+   * This test makes sure that encrypting the same string twice would yield a different result for
+   * different Events. This is important, as we don't want information to leak about two answers
+   * that were the same for different events.
    */
   @Test
   public void testNonDeterminism() {
     try {
-      Output encryptedOutput1 = (Output) encryptAnswer.invoke(crypto, output, keyPair.getPublic());
-      Output output2 = new Output();
-      output2.setName("name");
-      output2.setAnswer("answer");
-      Output encryptedOutput2 = (Output) encryptAnswer.invoke(crypto, output2, keyPair.getPublic());
+      Event event1 = new Event();
+      event1.setResponses(outputList);
+      event1.setServerExperimentId(42L);
 
-      assertThat(encryptedOutput1.getAnswer(), not(equalTo(encryptedOutput2.getAnswer())));
+      Event event2 = new Event();
+      Output output2 = new Output();
+      output2.setName(output.getName());
+      output2.setAnswer(output.getAnswer());
+      event2.setResponses(Arrays.asList(output2));
+      event2.setServerExperimentId(42L);
+
+      Event encryptedEvent1 = crypto.encryptAnswers(event1);
+      Event encryptedEvent2 = crypto.encryptAnswers(event2);
+
+      String answer1 = null;
+      for (Output output : encryptedEvent1.getResponses()) {
+        if (output.getName().equals("name"))
+          answer1 = output.getAnswer();
+      }
+      String answer2 = null;
+      for (Output output : encryptedEvent2.getResponses()) {
+        if (output.getName().equals("name"))
+          answer2 = output.getAnswer();
+      }
+
+      assertThat(answer1, not(equalTo(answer2)));
     } catch (Exception e) {
       fail("Exception when trying to encrypt: " + e);
     }
+  }
+
+  private byte[] decryptAsymmetric(String encrypted, PrivateKey privateKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+    cipher.init(Cipher.DECRYPT_MODE, privateKey);
+    byte[] encryptedBytes = Base64.decode(encrypted, Base64.NO_WRAP);
+    byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+    return decryptedBytes;
+  }
+
+  private byte[] decryptSymmetric(String encrypted, SecretKey secretKey, IvParameterSpec ivSpec) throws NoSuchPaddingException, NoSuchAlgorithmException, BadPaddingException, IllegalBlockSizeException, InvalidAlgorithmParameterException, InvalidKeyException {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
+    byte[] encryptedBytes = Base64.decode(encrypted, Base64.NO_WRAP);
+    return cipher.doFinal(encryptedBytes);
   }
 }

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -8,7 +8,8 @@ import com.pacoapp.paco.model.Event;
 import com.pacoapp.paco.model.Output;
 import com.pacoapp.paco.net.Crypto;
 
-import org.junit.Assert;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,10 +31,21 @@ public class CryptoTest extends AndroidTestCase {
   private Crypto crypto;
   private Method base64ToPublicKey;
   private Method encryptAnswer;
+  private KeyPair keyPair;
+  private Output output;
 
   @Before
   public void setUp() throws Exception {
     crypto = new Crypto(getContext());
+
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    keyPair = keyGen.genKeyPair();
+
+    output = new Output();
+    output.setName("name");
+    output.setAnswer("answer");
+
     // Make necessary methods accessible
     base64ToPublicKey = crypto.getClass().getDeclaredMethod("base64ToPublicKey", String.class);
     base64ToPublicKey.setAccessible(true);
@@ -50,19 +62,11 @@ public class CryptoTest extends AndroidTestCase {
 
     PublicKey decoded = (PublicKey) base64ToPublicKey.invoke(crypto, encoded64);
 
-    Assert.assertArrayEquals(publicKey, decoded.getEncoded());
+    assertArrayEquals(publicKey, decoded.getEncoded());
   }
 
   @Test
   public void testEncryptAnswer() throws NoSuchAlgorithmException, InvocationTargetException, IllegalAccessException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
-    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-    keyGen.initialize(2048);
-    KeyPair keyPair = keyGen.genKeyPair();
-
-    Output output = new Output();
-    output.setName("name");
-    output.setAnswer("answer");
-
     Output encryptedOutput = null;
     try {
       encryptedOutput = (Output) encryptAnswer.invoke(crypto, output, keyPair.getPublic());
@@ -78,5 +82,26 @@ public class CryptoTest extends AndroidTestCase {
     String decryptedAnswer = new String(decryptedBytes, "UTF-8");
 
     assertEquals(decryptedAnswer, "answer");
+  }
+
+  /**
+   * This test makes sure that encrypting the same string twice would yield a different result. This
+   * is part of non-determinism, which is needed because otherwise someone with access to the server
+   * DB could encrypt a string of plaintext with the public key of the experiment organizer, and
+   * check if the encrypted text corresponds to any data in the database.
+   */
+  @Test
+  public void testNonDeterminism() {
+    try {
+      Output encryptedOutput1 = (Output) encryptAnswer.invoke(crypto, output, keyPair.getPublic());
+      Output output2 = new Output();
+      output2.setName("name");
+      output2.setAnswer("answer");
+      Output encryptedOutput2 = (Output) encryptAnswer.invoke(crypto, output2, keyPair.getPublic());
+
+      assertThat(encryptedOutput1.getAnswer(), not(equalTo(encryptedOutput2.getAnswer())));
+    } catch (Exception e) {
+      fail("Exception when trying to encrypt: " + e);
+    }
   }
 }

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -1,0 +1,84 @@
+package com.google.android.apps.paco.test;
+
+import android.test.AndroidTestCase;
+import android.util.Base64;
+import android.util.Log;
+
+import com.pacoapp.paco.model.Event;
+import com.pacoapp.paco.model.Output;
+import com.pacoapp.paco.net.Crypto;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+public class CryptoTest extends AndroidTestCase {
+  private Crypto crypto;
+  private Method base64ToPublicKey;
+  private Method encryptAnswer;
+
+  @Before
+  public void setUp() throws Exception {
+    crypto = new Crypto(getContext());
+    // Make necessary methods accessible
+    base64ToPublicKey = crypto.getClass().getDeclaredMethod("base64ToPublicKey", String.class);
+    base64ToPublicKey.setAccessible(true);
+    encryptAnswer = crypto.getClass().getDeclaredMethod("encryptAnswer", Output.class, PublicKey.class);
+    encryptAnswer.setAccessible(true);
+  }
+
+  @Test
+  public void testBase64Decode() throws NoSuchAlgorithmException, InvocationTargetException, IllegalAccessException, UnsupportedEncodingException {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    byte[] publicKey = keyGen.genKeyPair().getPublic().getEncoded();
+    String encoded64 = Base64.encodeToString(publicKey, Base64.DEFAULT);
+
+    PublicKey decoded = (PublicKey) base64ToPublicKey.invoke(crypto, encoded64);
+
+    Assert.assertArrayEquals(publicKey, decoded.getEncoded());
+  }
+
+  @Test
+  public void testEncryptAnswer() throws NoSuchAlgorithmException, InvocationTargetException, IllegalAccessException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    KeyPair keyPair = keyGen.genKeyPair();
+
+    Output output = new Output();
+    output.setName("name");
+    output.setAnswer("answer");
+
+    Output encryptedOutput = null;
+    try {
+      encryptedOutput = (Output) encryptAnswer.invoke(crypto, output, keyPair.getPublic());
+    } catch (Exception e) {
+      fail("Exception when trying to encrypt: " + e);
+    }
+
+    Cipher cipher = Cipher.getInstance("RSA");
+    cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+    String encryptedAnswer = encryptedOutput.getAnswer();
+    byte[] encryptedBytes = Base64.decode(encryptedAnswer, Base64.DEFAULT);
+    byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+    String decryptedAnswer = new String(decryptedBytes, "UTF-8");
+
+    assertEquals(decryptedAnswer, "answer");
+  }
+}

--- a/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/CryptoTest.java
@@ -20,8 +20,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -48,7 +46,7 @@ public class CryptoTest extends AndroidTestCase {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
     keyGen.initialize(2048);
     byte[] publicKey = keyGen.genKeyPair().getPublic().getEncoded();
-    String encoded64 = Base64.encodeToString(publicKey, Base64.DEFAULT);
+    String encoded64 = Base64.encodeToString(publicKey, Base64.NO_WRAP);
 
     PublicKey decoded = (PublicKey) base64ToPublicKey.invoke(crypto, encoded64);
 
@@ -72,10 +70,10 @@ public class CryptoTest extends AndroidTestCase {
       fail("Exception when trying to encrypt: " + e);
     }
 
-    Cipher cipher = Cipher.getInstance("RSA");
+    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
     cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
     String encryptedAnswer = encryptedOutput.getAnswer();
-    byte[] encryptedBytes = Base64.decode(encryptedAnswer, Base64.DEFAULT);
+    byte[] encryptedBytes = Base64.decode(encryptedAnswer, Base64.NO_WRAP);
     byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
     String decryptedAnswer = new String(decryptedBytes, "UTF-8");
 

--- a/PacoTest/src/com/google/android/apps/paco/test/MockExperimentProviderUtil.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/MockExperimentProviderUtil.java
@@ -32,6 +32,15 @@ class MockExperimentProviderUtil extends ExperimentProviderUtil {
   }
 
   @Override
+  public Experiment getExperimentByServerId(long id) {
+    for (Experiment experiment : experimentList) {
+      if (experiment.getServerId() != null && experiment.getServerId().equals(id))
+        return experiment;
+    }
+    return null;
+  }
+
+  @Override
   public void updateJoinedExperiment(Experiment experiment) {
     Experiment experimentToDelete = null;
     for (Experiment e : experimentList) {

--- a/ServerTools/src/com/google/paco/cmdline/DecryptPacoJson.java
+++ b/ServerTools/src/com/google/paco/cmdline/DecryptPacoJson.java
@@ -1,0 +1,224 @@
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchProviderException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.io.UnsupportedEncodingException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * This class allows you to decrypt a JSON file exported by Paco with a given private key.
+ */
+class DecryptPacoJson {
+
+  static class SymmetricParameters {
+    private SecretKey mSecretKey;
+    private IvParameterSpec mIvParameterSpec;
+
+    public SecretKey getSecretKey() { return mSecretKey; }
+    public void setSecretKey(SecretKey secretKey) { this.mSecretKey = secretKey; }
+    public IvParameterSpec getIvParameterSpec() { return mIvParameterSpec; }
+    public void setIvParameterSpec(IvParameterSpec ivParameterSpec) { this.mIvParameterSpec = ivParameterSpec; }
+  }
+
+  public static void main(String[] args) throws NoSuchAlgorithmException, IOException, InvalidKeySpecException, JSONException {
+    String inputFilename = args[0];
+    String outputFilename = args[1];
+    String privateKeyEncoded = args[2];
+
+    PrivateKey privateKey = base64ToPrivateKey(privateKeyEncoded);
+    JSONArray input = jsonFromFile(inputFilename);
+
+    decryptJson(input, privateKey);
+  }
+
+  /**
+   * Decrypts a JSON array exported by Paco in place, using a given private RSA key.
+   * @param input The JSON array exported by Paco
+   * @param privateKey The private key of the experiment organizer
+   */
+  public static void decryptJson(JSONArray input, PrivateKey privateKey) throws JSONException {
+
+    for (int i = 0; i < input.length(); i++) {
+      JSONObject event = input.getJSONObject(i);
+      try {
+        JSONArray responses = event.getJSONArray("responses");
+        SymmetricParameters eventKey = getEventSecretKey(responses, privateKey);
+        if (eventKey != null) {
+          System.out.println("I'm gonna decrypt some " + responses.toString());
+          decryptAnswers(responses, eventKey);
+          System.out.println("I just decrypted these! " + responses.toString());
+        }
+      } catch (JSONException e) {
+        System.out.println("Found event without responses, ignoring.");
+      }
+    }
+  }
+
+  /**
+   * Generate a public/private RSA key pair for use with Paco.
+   * @return Two BASE64 encoded strings: an encoded version of the public key, and an encoded version
+   *          of the private key
+   */
+  public static String[] generateKey() throws NoSuchAlgorithmException, NoSuchProviderException, UnsupportedEncodingException {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    keyGen.initialize(2048);
+    KeyPair keyPair = keyGen.genKeyPair();
+    byte[] encodedPubKey = Base64.getEncoder().encode(keyPair.getPublic().getEncoded());
+    byte[] encodedPrivKey = Base64.getEncoder().encode(keyPair.getPrivate().getEncoded());
+    System.out.println("Here's a key pair for you. Its format is " + keyPair.getPrivate().getFormat() + keyPair.getPublic().getFormat() + "\n");
+    String pubString = new String(encodedPubKey, "UTF-8");
+    String privString = new String(encodedPrivKey, "UTF-8");
+    System.out.println("Public: " + pubString + "\n");
+    System.out.println("Private: " + privString);
+    return new String[] {pubString, privString};
+  }
+
+  private static void decryptAnswers(JSONArray responses, SymmetricParameters key) throws JSONException {
+    for (int i = 0; i < responses.length(); i++) {
+      JSONObject response = responses.getJSONObject(i);
+      if (!response.getString("name").equals("encryptionKey") && !response.getString("name").equals("encryptionIv")) {
+        String encryptedAnswer = "";
+        try {
+          encryptedAnswer = response.getString("answer");
+          String decryptedAnswer = decryptSymmetric(encryptedAnswer, key);
+          System.out.println("A decrypted answer for you: " + decryptedAnswer + " -- from " + encryptedAnswer);
+          response.put("answer", decryptedAnswer);
+        } catch (JSONException e) {
+          System.out.println("Scary. Response " + response.getString("name") + " has no answer. Ignoring.");
+        } catch (Exception e) {
+          System.out.println("Exception when trying to decrypt " + response.getString("name") + ": " + e);
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the secret key for an event in the Paco datastore
+   * @param responses Array of all responses for this event
+   * @return The parameters for symmetric encryption for this event (secret key and IV), or null if this event was not encrypted
+   */
+  private static SymmetricParameters getEventSecretKey(JSONArray responses, PrivateKey privateKey) throws JSONException {
+    String encryptionKeyEncrypted = null;
+    String encryptionIvEncrypted = null;
+
+    for (int i = 0; i < responses.length(); i++) {
+      JSONObject response = responses.getJSONObject(i);
+      try {
+        if (response.getString("name").equals("encryptionKey")) {
+          encryptionKeyEncrypted = response.getString("answer");
+        } else if (response.getString("name").equals("encryptionIv")) {
+          encryptionIvEncrypted = response.getString("answer");
+        }
+      } catch (JSONException e) {
+        System.out.println("Scary. This response has either no name or no answer: " + response);
+      }
+    }
+
+    if (encryptionKeyEncrypted == null) {
+      return null;
+    }
+    if (encryptionIvEncrypted == null) {
+      System.out.println("Scary. This response had an encryption key, but no IV.");
+      return null;
+    }
+
+    byte[] encryptionKeyDecrypted = null;
+    try {
+      encryptionKeyDecrypted = decryptAsymmetric(encryptionKeyEncrypted, privateKey);
+    } catch (Exception e) {
+      System.out.println("Problem when trying to decrypt key for event: " + e);
+      return null;
+    }
+    byte[] encryptionIvDecrypted = null;
+    try {
+      encryptionIvDecrypted = decryptAsymmetric(encryptionIvEncrypted, privateKey);
+    } catch (Exception e) {
+      System.out.println("Problem when trying to decrypt IV for event: " + e);
+      return null;
+    }
+    SymmetricParameters parameters = new SymmetricParameters();
+    parameters.setSecretKey(new SecretKeySpec(encryptionKeyDecrypted, "AES"));
+    parameters.setIvParameterSpec(new IvParameterSpec(encryptionIvDecrypted));
+
+    return parameters;
+  }
+
+  /**
+   * Decrypt a byte array using a given private RSA key.
+   * @param encrypted The byte array that was encrypted using the corresponding RSA public key
+   * @param privateKey A private RSA key.
+   * @return The unencrypted byte array.
+   */
+  private static byte[] decryptAsymmetric(String encrypted, PrivateKey privateKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+    cipher.init(Cipher.DECRYPT_MODE, privateKey);
+    byte[] encryptedBytes = Base64.getDecoder().decode(encrypted.getBytes("UTF-8"));
+    byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+    return decryptedBytes;
+  }
+
+  /**
+   * Decrypt a given string using the provided symmetric AES parameters
+   * @param encrypted The string that was encrypted using the corresponding AES parameters
+   * @param key The parameters for the decryption (key itself, and IV)
+   * @return An unencrypted version of the string
+   */
+  private static String decryptSymmetric(String encrypted, SymmetricParameters key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(Cipher.DECRYPT_MODE, key.getSecretKey(), key.getIvParameterSpec());
+    byte[] encryptedBytes = Base64.getDecoder().decode(encrypted);
+    byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+    return new String(decryptedBytes, "UTF-8");
+  }
+
+  /**
+   * Converts a provided BASE64 encoded public key to the corresponding RSA key
+   * @param privateKeyString A BASE64 encoded private key
+   * @return A RSA Private Key
+   */
+  public static PrivateKey base64ToPrivateKey(String privateKeyString) throws NoSuchAlgorithmException, InvalidKeySpecException, UnsupportedEncodingException {
+    // NO_WRAP is used for compatibility with apache's BASE64 encoder
+    byte[] decoded = Base64.getDecoder().decode(privateKeyString.getBytes("UTF-8"));
+    PKCS8EncodedKeySpec pkcs8privKey = new PKCS8EncodedKeySpec(decoded);
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    return keyFactory.generatePrivate(pkcs8privKey);
+  }
+
+  /**
+   * Reads a file containing a JSON array, as exported by Paco.
+   * @param fileName The name of the file
+   * @return A JSON array generated using the file's contents
+   */
+  public static JSONArray jsonFromFile(String fileName) throws IOException, JSONException {
+    BufferedReader reader = new BufferedReader(new FileReader(fileName));
+    StringBuilder builder = new StringBuilder();
+    String buf;
+    while ((buf = reader.readLine()) != null) {
+      builder.append(buf);
+    }
+    return new JSONArray(builder.toString());
+  }
+
+}

--- a/Shared/src/com/pacoapp/paco/shared/model2/ExperimentDAO.java
+++ b/Shared/src/com/pacoapp/paco/shared/model2/ExperimentDAO.java
@@ -52,12 +52,12 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
 
   // Visible for testing
   public ExperimentDAO(Long id, String title, String description, String informedConsentForm,
-      String email,
+      String email, String publicKey,
       String joinDate,
       String modifyDate, Boolean published, List<String> admins, List<String> publishedUsers,
       Boolean deleted, Integer version, Boolean recordPhoneDetails, List<ExperimentGroup> groups,
       List<Integer> extraDataDeclarations) {
-    super(id, title, description, informedConsentForm, email, joinDate, recordPhoneDetails, deleted, extraDataDeclarations, null, null, null, null, null);
+    super(id, title, description, informedConsentForm, email, publicKey, joinDate, recordPhoneDetails, deleted, extraDataDeclarations, null, null, null, null, null);
     this.id = id;
     this.title = title;
     this.description = description;

--- a/Shared/src/com/pacoapp/paco/shared/model2/ExperimentDAOCore.java
+++ b/Shared/src/com/pacoapp/paco/shared/model2/ExperimentDAOCore.java
@@ -31,6 +31,7 @@ public class ExperimentDAOCore extends ModelBase implements Validatable, Seriali
   protected String organization;
   protected String contactEmail;
   protected String contactPhone;
+  private String publicKey;
   protected String joinDate;
   protected Long id;
   protected String informedConsentForm;
@@ -41,7 +42,7 @@ public class ExperimentDAOCore extends ModelBase implements Validatable, Seriali
   private Date latestEndDate;
 
   public ExperimentDAOCore(Long id, String title, String description, String informedConsentForm,
-                           String creatorEmail,
+                           String creatorEmail, String publicKey,
                            String joinDate, Boolean recordPhoneDetails, Boolean deleted2,
                            List<Integer> extraDataCollectionDeclarationsList,
                            String organization, String contactPhone, String contactEmail,
@@ -55,6 +56,7 @@ public class ExperimentDAOCore extends ModelBase implements Validatable, Seriali
     this.organization = organization;
     this.contactEmail = contactEmail;
     this.contactPhone = contactPhone;
+    this.publicKey = publicKey;
     this.joinDate = joinDate;
     this.setRecordPhoneDetails(recordPhoneDetails);
     this.deleted = deleted != null ? deleted : false;
@@ -217,4 +219,11 @@ public class ExperimentDAOCore extends ModelBase implements Validatable, Seriali
   }
 
 
+  public String getPublicKey() {
+    return publicKey;
+  }
+
+  public void setPublicKey(String publicKey) {
+    this.publicKey = publicKey;
+  }
 }

--- a/Shared/src_non_j2objc/com/pacoapp/paco/shared/model/ExperimentDAO.java
+++ b/Shared/src_non_j2objc/com/pacoapp/paco/shared/model/ExperimentDAO.java
@@ -79,14 +79,14 @@ public class ExperimentDAO extends ExperimentDAOCore implements Serializable {
    * @param customHtml
    */
   public ExperimentDAO(Long id, String title, String description, String informedConsentForm,
-      String email, SignalingMechanismDAO[] signalingMechanisms, Boolean fixedDuration, Boolean questionsChange,
+      String email, String publicKey, SignalingMechanismDAO[] signalingMechanisms, Boolean fixedDuration, Boolean questionsChange,
       String startDate, String endDate, String hash, String joinDate,
       String modifyDate, Boolean published, String[] admins, String[] publishedUsers,
       Boolean deleted, Boolean webRecommended, Integer version, Boolean customRendering, String customRenderingCode,
       Integer feedbackType2, Boolean backgroundListen, String backgroundListenSourceIdentifier,
       Boolean accessibilityListen, Boolean logActions, Boolean recordPhoneDetails, List<Integer> extraDataCollectionDeclarations) {
 
-    super(id, title, description, informedConsentForm, email, fixedDuration, startDate, endDate, joinDate, backgroundListen,
+    super(id, title, description, informedConsentForm, email, publicKey, fixedDuration, startDate, endDate, joinDate, backgroundListen,
         backgroundListenSourceIdentifier, accessibilityListen, logActions, recordPhoneDetails, extraDataCollectionDeclarations);
     this.id = id;
     this.title = title;

--- a/Shared/src_non_j2objc/com/pacoapp/paco/shared/model/ExperimentDAOCore.java
+++ b/Shared/src_non_j2objc/com/pacoapp/paco/shared/model/ExperimentDAOCore.java
@@ -31,9 +31,10 @@ public class ExperimentDAOCore implements Serializable {
   private Boolean logActions;
   private Boolean recordPhoneDetails;
   protected List<Integer> extraDataCollectionDeclarations;
+  protected String publicKey;
 
   public ExperimentDAOCore(Long id, String title, String description, String informedConsentForm,
-                           String email, Boolean fixedDuration,
+                           String email, String publicKey, Boolean fixedDuration,
                            String startDate, String endDate, String joinDate, Boolean backgroundListen,
                            String backgroundListenSourceIdentifier, Boolean accessibilityListen,
                            Boolean logActions, Boolean recordPhoneDetails,
@@ -58,6 +59,7 @@ public class ExperimentDAOCore implements Serializable {
     } else {
       this.extraDataCollectionDeclarations = extraDataCollectionDeclarations;
     }
+    this.publicKey = publicKey;
   }
 
   /**
@@ -186,6 +188,13 @@ public class ExperimentDAOCore implements Serializable {
     this.extraDataCollectionDeclarations = extraDataDeclarations;
   }
 
+  public String getPublicKey() {
+    return publicKey;
+  }
+
+  public void setPublicKey(String publicKey) {
+    this.publicKey = publicKey;
+  }
 
 
 }

--- a/Shared/src_non_j2objc/com/pacoapp/paco/shared/model2/JsonConverter.java
+++ b/Shared/src_non_j2objc/com/pacoapp/paco/shared/model2/JsonConverter.java
@@ -114,6 +114,7 @@ public class JsonConverter {
                                                           experimentDAO.getDescription(),
                                                           experimentDAO.getInformedConsentForm(),
                                                           experimentDAO.getCreator(),
+                                                          experimentDAO.getPublicKey(),
                                                           getSignalingMechanismsBC(experimentDAO),
                                                           experimentGroup.getFixedDuration(),
                                                           false,
@@ -182,6 +183,7 @@ public class JsonConverter {
                                                                            experimentDAOCore.getDescription(),
                                                                            experimentDAOCore.getInformedConsentForm(),
                                                                            experimentDAOCore.getCreator(),
+                                                                           experimentDAOCore.getPublicKey(),
                                                                            experimentDAOCore.getEarliestStartDate() != null,
                                                                            TimeUtil.formatDate(experimentDAOCore.getEarliestStartDate().getTime()),
                                                                            TimeUtil.formatDate(experimentDAOCore.getLatestEndDate().getTime()),
@@ -467,7 +469,7 @@ public class JsonConverter {
       endDate = lastEndTime.toDateMidnight().toDate();
     }
     return new ExperimentDAOCore(experiment.getId(), experiment.getTitle(), experiment.getDescription(),
-                                 experiment.getInformedConsentForm(), experiment.getCreator(),
+                                 experiment.getInformedConsentForm(), experiment.getCreator(), experiment.getPublicKey(),
                                  experiment.getJoinDate(), experiment.getRecordPhoneDetails(), experiment.getDeleted(),
                                  experiment.getExtraDataCollectionDeclarations(), experiment.getOrganization(),
                                  experiment.getContactPhone(), experiment.getContactEmail(), earliestStartDate, endDate);


### PR DESCRIPTION
This change allows an experiment organizer to provide an RSA public key through the web interface, which will cause the Paco app to encrypt all answers before they are sent to the server.

This makes sure that admins or server operators are not able to see the answers in the database, but the experiment organizer can still decrypt them using his/her private key.