### PR TITLE
Fix double permissions

### DIFF
--- a/PacoTest/src/com/google/android/apps/paco/test/RuntimePermissionMonitorServiceTest.java
+++ b/PacoTest/src/com/google/android/apps/paco/test/RuntimePermissionMonitorServiceTest.java
@@ -1,6 +1,8 @@
 package com.google.android.apps.paco.test;
 
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.test.AndroidTestCase;
 
 import com.pacoapp.paco.sensors.android.RuntimePermissionMonitorService;
@@ -9,14 +11,21 @@ import com.pacoapp.paco.sensors.android.procmon.EncounteredPermissionRequest;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class RuntimePermissionMonitorServiceTest extends AndroidTestCase {
   RuntimePermissionMonitorService runtimePermissionMonitorService;
   Method extractInformationFromEventText;
   Method setCurrentlyHandledAppName;
+  Field previouslyEncounteredPermissionRequests;
 
   @Before
   public void setUp() throws Exception {
@@ -25,11 +34,13 @@ public class RuntimePermissionMonitorServiceTest extends AndroidTestCase {
     Method init = runtimePermissionMonitorService.getClass().getDeclaredMethod("onServiceConnected");
     init.setAccessible(true);
     init.invoke(runtimePermissionMonitorService);
-    // Make necessary methods accessible
+    // Make necessary methods and fields accessible
     extractInformationFromEventText = runtimePermissionMonitorService.getClass().getDeclaredMethod("extractInformationFromEventText", List.class);
     extractInformationFromEventText.setAccessible(true);
     setCurrentlyHandledAppName = runtimePermissionMonitorService.getClass().getDeclaredMethod("setCurrentlyHandledAppName", CharSequence.class);
     setCurrentlyHandledAppName.setAccessible(true);
+    previouslyEncounteredPermissionRequests = runtimePermissionMonitorService.getClass().getDeclaredField("previouslyEncounteredPermissionRequests");
+    previouslyEncounteredPermissionRequests.setAccessible(true);
   }
 
   @Test
@@ -50,6 +61,24 @@ public class RuntimePermissionMonitorServiceTest extends AndroidTestCase {
     EncounteredPermissionRequest lastRequest = runtimePermissionMonitorService.getLastEncounteredPermissionRequest();
     assertEquals(lastRequest.getAppName(), "Bramapp");
     assertEquals(lastRequest.getPermissionString(), "Camera");
+  }
+
+  @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+  @Test
+  public void testDuplicateAdd() throws Exception {
+    List<CharSequence> input1 = new ArrayList();
+    input1.add("Allow Bramapp to access this device's location?");
+    List<CharSequence> input2 = new ArrayList();
+    input2.add("Allow Bramapp to take pictures and record video?");
+    extractInformationFromEventText.invoke(runtimePermissionMonitorService, input1);
+    extractInformationFromEventText.invoke(runtimePermissionMonitorService, input2);
+    extractInformationFromEventText.invoke(runtimePermissionMonitorService, input2);
+
+    Deque<EncounteredPermissionRequest> encounteredPermissionRequests = (Deque<EncounteredPermissionRequest>) previouslyEncounteredPermissionRequests.get(runtimePermissionMonitorService);
+
+    // Make sure the last add was ignored
+    assertEquals(encounteredPermissionRequests.size(), 2);
+    assertThat(encounteredPermissionRequests.getFirst().getPermissionString(), not(equalTo(encounteredPermissionRequests.getLast().getPermissionString())));
   }
 
   @Test


### PR DESCRIPTION
Fix for the situation where the accessibility service might trigger the same window change event twice (for runtime permissions). Prevent the same permission from being added twice.