### PR TITLE
Bug fix (ios): Notification object not removed after being fired

### DIFF
--- a/Paco-iOS/Paco/source/core/scheduling/PacoNotificationManager.m
+++ b/Paco-iOS/Paco/source/core/scheduling/PacoNotificationManager.m
@@ -111,7 +111,19 @@ static NSString* kNotificationPlistName = @"notificationDictionary.plist";
     if (0 == [notifications count]) {
       return;
     }
-    [notifications removeObject:notification];
+    
+    //The passed notification object is identical to but not the same
+    //as the fired notification object.
+    //Therefore removeObject fails to remove the notification from the array.
+    //Since at this point, the array is already filtered by experimentId, we
+    //can just use the predicate to remove the fired notification object.
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"fireDate == %@", notification.fireDate];
+    NSArray *filteredArray = [notifications filteredArrayUsingPredicate:predicate];
+    id firstFoundObject = nil;
+    firstFoundObject =  filteredArray.count > 0 ? filteredArray.firstObject : nil;
+    [notifications removeObject:firstFoundObject];
+    
     (self.notificationDict)[experimentId] = notifications;
     DDLogInfo(@"New Notification Dict: %@", [self.notificationDict pacoDescriptionForNotificationDict]);
     [self saveNotificationsToCache];


### PR DESCRIPTION
 Bug fix (ios): Notification object not removed after being fired


 Bug fix (ios): Notification object not removed after being fired 
Problem: Since the notification object is not removed when opened directly from the home screen or notification view, the icon badge number is not removed and also the 'Time for participation' appears, creating double data to the researcher and confusions to the participants. The reason behind this is the notification object that is passed is identical to the fired object but the pointer is different and hence here the removeObject fails.

A predicate on filtered array of notifications of the particular experiment id solves the issue.