### PR TITLE
Add 3 Desktop Data Logger Group Types

### DIFF
--- a/Paco-Server/ear/default/web/js/controllers.js
+++ b/Paco-Server/ear/default/web/js/controllers.js
@@ -339,8 +339,20 @@ pacoApp.controller('ExperimentCtrl', [
         matchingInputObj = template.inputsForPredefinedGroupPhoneStatus;
         grObject.fixedDuration = true;
         grObject.logShutdown = true;
-      } 
-      
+      } else if (groupType === 'APPUSAGE_DESKTOP') {
+         matchingInputObj = template.inputsForPredefinedGroupAppUsageDesktop;
+         grObject.fixedDuration = true;
+         grObject.logActions = true;
+      } else if (groupType === 'APPUSAGE_SHELL') {
+        matchingInputObj = template.inputsForPredefinedGroupAppUsageShell;
+        grObject.fixedDuration = true;
+        grObject.logActions = true;
+      }  else if (groupType === 'IDE_IDEA_USAGE') {
+         matchingInputObj = template.inputsForPredefinedGroupIdeIdeaUsage;
+         grObject.fixedDuration = true;
+         grObject.logActions = true;
+      }
+
       if (grObject.fixedDuration) {
         $scope.startDate = new Date();
         $scope.endDate = new Date($scope.startDate.getTime() + (24 * 60 * 60 * 1000));
@@ -1055,6 +1067,12 @@ pacoApp.controller('InputCtrl', ['$scope', 'config', 'template', function ($scop
       matchingInputObj = template.inputsForPredefinedGroupPhoneStatus;
     } else if (groupType === 'SYSTEM') {
       matchingInputObj = template.inputsForPredefinedGroupSystemAndAdvanced;
+    } else if (groupType === 'APPUSAGE_DESKTOP') {
+      matchingInputObj = template.inputsForPredefinedGroupAppUsageDesktop;
+    } else if (groupType === 'APPUSAGE_SHELL') {
+      matchingInputObj = template.inputsForPredefinedGroupAppUsageShell;
+    } else if (groupType === 'IDE_IDEA_USAGE') {
+      matchingInputObj = template.inputsForPredefinedGroupIdeIdeaUsage;
     } else {
       return false;
     }

--- a/Paco-Server/ear/default/web/js/services.js
+++ b/Paco-Server/ear/default/web/js/services.js
@@ -664,6 +664,27 @@ pacoApp.service('template', function() {
     {"name" : 'accessibilityEventType',"required": false,"conditional": false, "text" : 'accessibilityEventType', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
     {"name" : 'accessibilityEventContentDescription',"required": false,"conditional": false, "text" : 'accessibilityEventContentDescription', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true}
     ];
+  this.inputsForPredefinedGroupAppUsageDesktop =[
+    {"name" : 'apps_used', "required": false,"conditional": false, "text" : 'apps_used', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'apps_used_raw',"required": false, "conditional": false,"text" : 'apps_used_raw',"likertSteps": 5, "responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'foreground',"required": false,"conditional": false, "text" : 'foreground', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userPresent',"required": false,"conditional": false, "text" : 'userPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userNotPresent',"required": false,"conditional": false, "text" : 'userNotPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true}
+    ];
+  this.inputsForPredefinedGroupAppUsageShell =[
+    {"name" : 'apps_used', "required": false,"conditional": false, "text" : 'apps_used', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'apps_used_raw',"required": false, "conditional": false,"text" : 'apps_used_raw',"likertSteps": 5, "responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'foreground',"required": false,"conditional": false, "text" : 'foreground', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userPresent',"required": false,"conditional": false, "text" : 'userPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userNotPresent',"required": false,"conditional": false, "text" : 'userNotPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true}
+    ];
+  this.inputsForPredefinedGroupIdeIdeaUsage =[
+    {"name" : 'apps_used', "required": false,"conditional": false, "text" : 'apps_used', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'apps_used_raw',"required": false, "conditional": false,"text" : 'apps_used_raw',"likertSteps": 5, "responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'foreground',"required": false,"conditional": false, "text" : 'foreground', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userPresent',"required": false,"conditional": false, "text" : 'userPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true},
+    {"name" : 'userNotPresent',"required": false,"conditional": false, "text" : 'userNotPresent', "likertSteps": 5,"responseType" : 'open text', "multiselect": false, "predefined":true}
+    ];
 });
 
 

--- a/Paco-Server/ear/default/web/partials/data collectors.html
+++ b/Paco-Server/ear/default/web/partials/data collectors.html
@@ -29,7 +29,7 @@
 			          		<a href="" class="removeGroup" ng-click="remove(experiment.groups, $index)"></a>
 						</div>
 					 </div>	
-      				<div ng-switch-when="PHONESTATUS|APPUSAGE_ANDROID" ng-switch-when-separator="|">
+      				<div ng-switch-when="PHONESTATUS|APPUSAGE_ANDROID|APPUSAGE_DESKTOP|APPUSAGE_SHELL|IDE_IDEA_USAGE" ng-switch-when-separator="|">
 	      				<div class="section">
 			          			<div class="title" ng-click="toggleHide()">
 						            <a href="" class="group-toggle" ng-class="{hiding: hiding}"></a>
@@ -72,7 +72,7 @@
 		          		</md-radio-group>
 					</div>
 					
-					<div class="title" ng-switch-when="APPUSAGE_ANDROID|PHONESTATUS" ng-switch-when-separator="|">
+					<div class="title" ng-switch-when="APPUSAGE_ANDROID|PHONESTATUS|APPUSAGE_DESKTOP|APPUSAGE_SHELL|IDE_IDEA_USAGE" ng-switch-when-separator="|">
 					<!-- Nothing -->
 						<label>Fixed</label>
 					</div>

--- a/Paco-Server/ear/default/web/partials/sensorgroup.html
+++ b/Paco-Server/ear/default/web/partials/sensorgroup.html
@@ -15,6 +15,15 @@
      <md-button name = "PHONESTATUS" ng-click="addSensorGroup('PHONESTATUS')" class="md-primary">
       PhoneStatus
     </md-button>
+     <md-button name = "APPUSAGE_DESKTOP" ng-click="addSensorGroup('APPUSAGE_DESKTOP')" class="md-primary">
+         AppUsage Desktop
+     </md-button>
+     <md-button name = "APPUSAGE_SHELL" ng-click="addSensorGroup('APPUSAGE_SHELL')" class="md-primary">
+         AppUsage Shell
+     </md-button>
+     <md-button name = "IDE_IDEA_USAGE" ng-click="addSensorGroup('IDE_IDEA_USAGE')" class="md-primary">
+         Idea-based IDE Usage
+     </md-button>
 
      </md-dialog-content>
    <md-dialog-actions>

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/MigrationLookupTable.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/MigrationLookupTable.java
@@ -22,6 +22,7 @@ import com.google.sampling.experiential.server.migration.jobs.ExperimentTitleLow
 import com.google.sampling.experiential.server.migration.jobs.FeedbackTypeRepairMigration;
 import com.google.sampling.experiential.server.migration.jobs.TestJDODSCompat;
 import com.google.sampling.experiential.server.stats.usage.UsageStatsBackfillJob;
+import com.google.sampling.experiential.server.migration.jobs.AddDesktopStudyGroupTypes;
 
 public class MigrationLookupTable {
   private static final Logger log = Logger.getLogger(MigrationLookupTable.class.getName());
@@ -45,6 +46,7 @@ public class MigrationLookupTable {
     migrations.put("28", EVGMigrationVerificationJob.class);
     migrations.put("29", DeleteExperimentDataJob.class);
     migrations.put("100", ExperimentTitleLowercaseMigrationJob.class);
+    migrations.put("101", AddDesktopStudyGroupTypes.class);
   }
   
   public static MigrationJob getMigrationByName(String name) {

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/MigrationLookupTable.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/MigrationLookupTable.java
@@ -5,24 +5,8 @@ import java.util.logging.Logger;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import com.google.sampling.experiential.server.migration.jobs.CSInsertEventsJob;
-import com.google.sampling.experiential.server.migration.jobs.CSInsertOutputsJob;
-import com.google.sampling.experiential.server.migration.jobs.CatchUpDateRangeJob;
-import com.google.sampling.experiential.server.migration.jobs.CatchUpDateRangeJobOldVersion;
-import com.google.sampling.experiential.server.migration.jobs.ConvertEventV4ToV5Job;
-import com.google.sampling.experiential.server.migration.jobs.CopyExperimentFromDataStoreToCloudSqlJob;
-import com.google.sampling.experiential.server.migration.jobs.DeleteExperimentDataJob;
-import com.google.sampling.experiential.server.migration.jobs.EVGMigrationVerificationJob;
-import com.google.sampling.experiential.server.migration.jobs.EventStatsCounterMigrationJob;
-import com.google.sampling.experiential.server.migration.jobs.ExperimentHubMigrationJob;
-import com.google.sampling.experiential.server.migration.jobs.ExperimentJDOToDatastoreMigration;
-import com.google.sampling.experiential.server.migration.jobs.ExperimentMigrationDataPreCleanupJob;
-import com.google.sampling.experiential.server.migration.jobs.ExperimentSplitAndPersistJob;
-import com.google.sampling.experiential.server.migration.jobs.ExperimentTitleLowercaseMigrationJob;
-import com.google.sampling.experiential.server.migration.jobs.FeedbackTypeRepairMigration;
-import com.google.sampling.experiential.server.migration.jobs.TestJDODSCompat;
+import com.google.sampling.experiential.server.migration.jobs.*;
 import com.google.sampling.experiential.server.stats.usage.UsageStatsBackfillJob;
-import com.google.sampling.experiential.server.migration.jobs.AddDesktopStudyGroupTypes;
 
 public class MigrationLookupTable {
   private static final Logger log = Logger.getLogger(MigrationLookupTable.class.getName());
@@ -46,7 +30,7 @@ public class MigrationLookupTable {
     migrations.put("28", EVGMigrationVerificationJob.class);
     migrations.put("29", DeleteExperimentDataJob.class);
     migrations.put("100", ExperimentTitleLowercaseMigrationJob.class);
-    migrations.put("101", AddDesktopStudyGroupTypes.class);
+    migrations.put("101", AddDesktopStudyGroupTypesJob.class);
   }
   
   public static MigrationJob getMigrationByName(String name) {

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypes.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypes.java
@@ -1,0 +1,187 @@
+package com.google.sampling.experiential.server.migration.jobs;
+
+import com.google.sampling.experiential.cloudsql.columns.GroupTypeColumns;
+import com.google.sampling.experiential.dao.CSGroupTypeDao;
+import com.google.sampling.experiential.dao.CSGroupTypeInputMappingDao;
+import com.google.sampling.experiential.dao.CSInputDao;
+import com.google.sampling.experiential.dao.dataaccess.DataType;
+import com.google.sampling.experiential.dao.dataaccess.GroupTypeInputMapping;
+import com.google.sampling.experiential.dao.dataaccess.Input;
+import com.google.sampling.experiential.dao.dataaccess.PredefinedInputNames;
+import com.google.sampling.experiential.dao.impl.CSGroupTypeDaoImpl;
+import com.google.sampling.experiential.dao.impl.CSGroupTypeInputMappingDaoImpl;
+import com.google.sampling.experiential.dao.impl.CSInputDaoImpl;
+import com.google.sampling.experiential.server.CloudSQLConnectionManager;
+import com.google.sampling.experiential.server.ExceptionUtil;
+import com.pacoapp.paco.shared.model2.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+public class AddDesktopStudyGroupTypes {
+  public static final Logger log = Logger.getLogger(AddDesktopStudyGroupTypes.class.getName());
+
+  final String insertDataTypeSql1000 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+          "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.APPUSAGE_DESKTOP + "')";
+  final String insertDataTypeSql1001 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+          "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.APPUSAGE_SHELL + "')";
+  final String insertDataTypeSql1002 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+          "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.IDE_IDEA_USAGE + "')";
+
+  public boolean dataCleanupInsertPredefinedRecords() throws Exception {
+    String[] insertionQueries = new String[]{
+            insertDataTypeSql1000,
+            insertDataTypeSql1001,
+            insertDataTypeSql1002
+    };
+    executeCreationOrInsertionQuerys(insertionQueries);
+    // pop grp type input
+    populateGroupTypeInput();
+    return true;
+  }
+
+  private boolean populateGroupTypeInput() throws Exception {
+
+    CSInputDao inputDaoImpl = new CSInputDaoImpl();
+    CSGroupTypeInputMappingDao predfinedDaoImpl = new CSGroupTypeInputMappingDaoImpl();
+    CSGroupTypeDao groupTypeDapImpl = new CSGroupTypeDaoImpl();
+    DataType openTextDataType = new DataType("open text", false, false);
+
+    try {
+      addAppUsageDesktopGroup(inputDaoImpl, predfinedDaoImpl, groupTypeDapImpl, openTextDataType);
+      addAppUsageShellGroup(inputDaoImpl, predfinedDaoImpl, groupTypeDapImpl, openTextDataType);
+      addIdeIdeaUsageGroup(inputDaoImpl, predfinedDaoImpl, groupTypeDapImpl, openTextDataType);
+    } catch (SQLException sqle) {
+      log.warning("SQLException while adding new group type " + ExceptionUtil.getStackTraceAsString(sqle));
+      throw sqle;
+    } catch (Exception e) {
+      log.warning("GException while adding new group type " + ExceptionUtil.getStackTraceAsString(e));
+      throw e;
+    }
+    return true;
+  }
+
+  private void addAppUsageDesktopGroup(CSInputDao inputDaoImpl, CSGroupTypeInputMappingDao predfinedDaoImpl, CSGroupTypeDao groupTypeDapImpl, DataType openTextDataType) throws Exception {
+    Input appsUsedInput = new Input(PredefinedInputNames.APPS_USED, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED, 0, null, null, null);
+    Input appUsageRawInput = new Input(PredefinedInputNames.APPS_USED_RAW, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED_RAW, 0, null, null, null);
+    Input foregroundInput = new Input(PredefinedInputNames.FOREGROUND, false, null, openTextDataType,
+            PredefinedInputNames.FOREGROUND, 0, null, null, null);
+    Input userPresentInput = new Input(PredefinedInputNames.USER_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_PRESENT, 0, null, null, null);
+    Input userNotPresentInput = new Input(PredefinedInputNames.USER_NOT_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_NOT_PRESENT, 0, null, null, null);
+
+    Integer groupId = groupTypeDapImpl.getGroupTypeId(GroupTypeEnum.APPUSAGE_DESKTOP.name());
+
+    inputDaoImpl.insertInput(appsUsedInput);
+    inputDaoImpl.insertInput(appUsageRawInput);
+    inputDaoImpl.insertInput(foregroundInput);
+    inputDaoImpl.insertInput(userPresentInput);
+    inputDaoImpl.insertInput(userNotPresentInput);
+
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appsUsedInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appUsageRawInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, foregroundInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userPresentInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userNotPresentInput));
+  }
+
+  private void addAppUsageShellGroup(CSInputDao inputDaoImpl, CSGroupTypeInputMappingDao predfinedDaoImpl, CSGroupTypeDao groupTypeDapImpl, DataType openTextDataType) throws Exception {
+    Input appsUsedInput = new Input(PredefinedInputNames.APPS_USED, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED, 0, null, null, null);
+    Input appUsageRawInput = new Input(PredefinedInputNames.APPS_USED_RAW, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED_RAW, 0, null, null, null);
+    Input foregroundInput = new Input(PredefinedInputNames.FOREGROUND, false, null, openTextDataType,
+            PredefinedInputNames.FOREGROUND, 0, null, null, null);
+    Input userPresentInput = new Input(PredefinedInputNames.USER_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_PRESENT, 0, null, null, null);
+    Input userNotPresentInput = new Input(PredefinedInputNames.USER_NOT_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_NOT_PRESENT, 0, null, null, null);
+
+    Integer groupId = groupTypeDapImpl.getGroupTypeId(GroupTypeEnum.APPUSAGE_SHELL.name());
+
+    inputDaoImpl.insertInput(appsUsedInput);
+    inputDaoImpl.insertInput(appUsageRawInput);
+    inputDaoImpl.insertInput(foregroundInput);
+    inputDaoImpl.insertInput(userPresentInput);
+    inputDaoImpl.insertInput(userNotPresentInput);
+
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appsUsedInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appUsageRawInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, foregroundInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userPresentInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userNotPresentInput));
+  }
+
+  private void addIdeIdeaUsageGroup(CSInputDao inputDaoImpl, CSGroupTypeInputMappingDao predfinedDaoImpl,
+                                    CSGroupTypeDao groupTypeDapImpl, DataType openTextDataType) throws Exception {
+    Input appsUsedInput = new Input(PredefinedInputNames.APPS_USED, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED, 0, null, null, null);
+    Input appUsageRawInput = new Input(PredefinedInputNames.APPS_USED_RAW, false, null, openTextDataType,
+            PredefinedInputNames.APPS_USED_RAW, 0, null, null, null);
+    Input foregroundInput = new Input(PredefinedInputNames.FOREGROUND, false, null, openTextDataType,
+            PredefinedInputNames.FOREGROUND, 0, null, null, null);
+    Input userPresentInput = new Input(PredefinedInputNames.USER_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_PRESENT, 0, null, null, null);
+    Input userNotPresentInput = new Input(PredefinedInputNames.USER_NOT_PRESENT, false, null, openTextDataType,
+            PredefinedInputNames.USER_NOT_PRESENT, 0, null, null, null);
+
+    Integer groupId = groupTypeDapImpl.getGroupTypeId(GroupTypeEnum.IDE_IDEA_USAGE.name());
+
+    inputDaoImpl.insertInput(appsUsedInput);
+    inputDaoImpl.insertInput(appUsageRawInput);
+    inputDaoImpl.insertInput(foregroundInput);
+    inputDaoImpl.insertInput(userPresentInput);
+    inputDaoImpl.insertInput(userNotPresentInput);
+
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appsUsedInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, appUsageRawInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, foregroundInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userPresentInput));
+    predfinedDaoImpl.insertGroupTypeInputMapping(new GroupTypeInputMapping(groupId, userNotPresentInput));
+  }
+
+
+  private boolean executeCreationOrInsertionQuerys(String[] creationQrys) throws SQLException {
+    boolean isComplete = false;
+
+    Connection conn = null;
+    PreparedStatement statementCreateOrInsertQuery = null;
+
+    try {
+      conn = CloudSQLConnectionManager.getInstance().getConnection();
+      for (int i = 0; i < creationQrys.length; i++) {
+        statementCreateOrInsertQuery = conn.prepareStatement(creationQrys[i]);
+        log.info(creationQrys[i]);
+        statementCreateOrInsertQuery.execute();
+      }
+      isComplete = true;
+    } catch (SQLException sqle) {
+      log.warning("SQLException while creating tables" + ExceptionUtil.getStackTraceAsString(sqle));
+      throw sqle;
+    } catch (Exception e) {
+      log.warning("GException while creating tables" + ExceptionUtil.getStackTraceAsString(e));
+      throw e;
+    } finally {
+      try {
+        if (statementCreateOrInsertQuery != null) {
+          statementCreateOrInsertQuery.close();
+        }
+
+        if (conn != null) {
+          conn.close();
+        }
+      } catch (SQLException e) {
+        log.warning("Exception in finally block" + ExceptionUtil.getStackTraceAsString(e));
+      }
+    }
+
+    return isComplete;
+  }
+
+
+}

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypes.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypes.java
@@ -23,26 +23,24 @@ import java.util.logging.Logger;
 public class AddDesktopStudyGroupTypes {
   public static final Logger log = Logger.getLogger(AddDesktopStudyGroupTypes.class.getName());
 
-  final String insertDataTypeSql1000 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+  final String insertAppUsageDesktopType = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
           "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.APPUSAGE_DESKTOP + "')";
-  final String insertDataTypeSql1001 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+  final String insertAppUsageShellType = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
           "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.APPUSAGE_SHELL + "')";
-  final String insertDataTypeSql1002 = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
+  final String insertIdeIdeaUsageType = "INSERT INTO `pacodb`.`" + GroupTypeColumns.TABLE_NAME +
           "` (`" + GroupTypeColumns.GROUP_TYPE_NAME + "`) VALUES ('" + GroupTypeEnum.IDE_IDEA_USAGE + "')";
 
-  public boolean dataCleanupInsertPredefinedRecords() throws Exception {
-    String[] insertionQueries = new String[]{
-            insertDataTypeSql1000,
-            insertDataTypeSql1001,
-            insertDataTypeSql1002
-    };
-    executeCreationOrInsertionQuerys(insertionQueries);
-    // pop grp type input
-    populateGroupTypeInput();
+  public boolean insertNewGroupTypes() throws Exception {
+    executeCreationOrInsertionQueries(new String[]{
+            insertAppUsageDesktopType,
+            insertAppUsageShellType,
+            insertIdeIdeaUsageType
+    });
+    populateInputsForGroupTypes();
     return true;
   }
 
-  private boolean populateGroupTypeInput() throws Exception {
+  private boolean populateInputsForGroupTypes() throws Exception {
 
     CSInputDao inputDaoImpl = new CSInputDaoImpl();
     CSGroupTypeInputMappingDao predfinedDaoImpl = new CSGroupTypeInputMappingDaoImpl();
@@ -146,7 +144,7 @@ public class AddDesktopStudyGroupTypes {
   }
 
 
-  private boolean executeCreationOrInsertionQuerys(String[] creationQrys) throws SQLException {
+  private boolean executeCreationOrInsertionQueries(String[] creationQrys) throws SQLException {
     boolean isComplete = false;
 
     Connection conn = null;

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypesJob.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypesJob.java
@@ -9,27 +9,19 @@ import java.util.logging.Logger;
 
 public class AddDesktopStudyGroupTypesJob implements MigrationJob {
 
-    public static final Logger log = Logger.getLogger(AddDesktopStudyGroupTypesJob.class.getName());
+  public static final Logger log = Logger.getLogger(AddDesktopStudyGroupTypesJob.class.getName());
 
-    @Override
-    public boolean doMigration(String cursor, DateTime startTime, DateTime endTime) {
-      try {
-        cleanupDataBeforeMigration(cursor);
-        return true;
-      } catch (Exception e) { 
-        log.warning(ExceptionUtil.getStackTraceAsString(e));
-        return false;
-      }
+  @Override
+  public boolean doMigration(String cursor, DateTime startTime, DateTime endTime) {
+    try {
+      log.info("------------------------------------------------Begin------------------------------------------------");
+      AddDesktopStudyGroupTypes migrator = new AddDesktopStudyGroupTypes();
+      migrator.insertNewGroupTypes();
+      log.info("------------------------------------------------End------------------------------------------------");
+      return true;
+    } catch (Exception e) {
+      log.warning(ExceptionUtil.getStackTraceAsString(e));
     }
-    
-    private void cleanupDataBeforeMigration(String cursor) throws Exception {
-      try {
-        log.info("------------------------------------------------Begin------------------------------------------------");
-        AddDesktopStudyGroupTypes migrator = new AddDesktopStudyGroupTypes();
-        migrator.dataCleanupInsertPredefinedRecords();
-        log.info("------------------------------------------------End------------------------------------------------");
-      } catch (SQLException e) {
-        throw new SQLException("Failed to insert data types.", e);
-      }
-    }
+    return false;
+  }
 }

--- a/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypesJob.java
+++ b/Paco-Server/src/com/google/sampling/experiential/server/migration/jobs/AddDesktopStudyGroupTypesJob.java
@@ -1,0 +1,35 @@
+package com.google.sampling.experiential.server.migration.jobs;
+
+import com.google.sampling.experiential.server.ExceptionUtil;
+import com.google.sampling.experiential.server.migration.MigrationJob;
+import org.joda.time.DateTime;
+
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+public class AddDesktopStudyGroupTypesJob implements MigrationJob {
+
+    public static final Logger log = Logger.getLogger(AddDesktopStudyGroupTypesJob.class.getName());
+
+    @Override
+    public boolean doMigration(String cursor, DateTime startTime, DateTime endTime) {
+      try {
+        cleanupDataBeforeMigration(cursor);
+        return true;
+      } catch (Exception e) { 
+        log.warning(ExceptionUtil.getStackTraceAsString(e));
+        return false;
+      }
+    }
+    
+    private void cleanupDataBeforeMigration(String cursor) throws Exception {
+      try {
+        log.info("------------------------------------------------Begin------------------------------------------------");
+        AddDesktopStudyGroupTypes migrator = new AddDesktopStudyGroupTypes();
+        migrator.dataCleanupInsertPredefinedRecords();
+        log.info("------------------------------------------------End------------------------------------------------");
+      } catch (SQLException e) {
+        throw new SQLException("Failed to insert data types.", e);
+      }
+    }
+}

--- a/Shared/src/com/pacoapp/paco/shared/model2/GroupTypeEnum.java
+++ b/Shared/src/com/pacoapp/paco/shared/model2/GroupTypeEnum.java
@@ -6,8 +6,11 @@ public enum GroupTypeEnum {
   APPUSAGE_ANDROID(3), 
   NOTIFICATION(4),
   ACCESSIBILITY(5),
-  PHONESTATUS(6);
-  
+  PHONESTATUS(6),
+  APPUSAGE_DESKTOP(7),
+  APPUSAGE_SHELL(8),
+  IDE_IDEA_USAGE(9);
+
   private int groupTypeId;
   
   private GroupTypeEnum(int groupTypeId) {


### PR DESCRIPTION
To support desktop research, we are adding three new Group Types (Data Collector Types):
APPUSAGE_DESKTOP, APPUSAGE_SHELL, IDE_IDEA_USAGE
The last one is IDE logging for IDEA-based IDEs, e.g., IntelliJ, Android Studio, CLion, etc.

The PR defines types in GroupTypeEnum and also creates a server migration job to populate the predefined inputs for the data collectors in the sql tables.

One question I have is what are the predefined Inputs for data collection. This is an optional feature that can help with some server side display and analysis functions. For example for the APPUSAGE_Android data collector, it always collects 5 variables APPS_USED, APPS_USED_RAW, FOREGROUND, USER_PRESENT, USER_NOT_PRESENT.

I have all three of the new collectors the same. I am not sure if that is right for the shell collector as I haven't seen output for the shell collector yet. Also, I am unsure if it makes sense or is possible for it to record user present/user_not_present events. I am not sure if it can collect Foreground either.

As a note, additional fields created by the input do not need to be predefined. It is just a bonus, especially non open-text types, because we can then provide more analytical options based on those better defined types (as compared to String types, the default). 