### PR TITLE
Add trigger cues for desktop events

### DIFF
--- a/Paco-Server/ear/default/web/js/services.js
+++ b/Paco-Server/ear/default/web/js/services.js
@@ -461,7 +461,12 @@ pacoApp.service('config', function() {
     "Notification shade dismiss all",
     "Notification shade dismiss notification",
     "Notification shade closed",
-    "Notification tapped in shade"
+    "Notification tapped in shade",
+    "App Started on Desktop",
+    "App Stopped on Desktop",
+    "App Started in Shell",
+    "App Stopped in Shell",
+    "Idea-based IDE Usage"
   ];
 
   this.esmPeriods = [

--- a/Paco-Server/ear/default/web/partials/cue.html
+++ b/Paco-Server/ear/default/web/partials/cue.html
@@ -13,16 +13,43 @@
     
 
 	    <div layout="row" >
-	      <md-input-container ng-if="cue.cueCode === 3 || cue.cueCode === 4 || cue.cueCode === 5 || cue.cueCode === 18" flex=90>
+	      <md-input-container ng-if="cue.cueCode === 3" flex=90>
 	        <label>Source of Paco Action</label>
-	        <input type="text" ng-model="cue.cueSource" placeholder="Source Android Package name">
+	        <input type="text" ng-model="cue.cueSource">
 	      </md-input-container>
-      <paco-help tip="app-triggers" ng-if="cue.cueCode === 4 || cue.cueCode === 5 || cue.cueCode === 18" >
+
+            <md-input-container ng-if="cue.cueCode === 4 || cue.cueCode === 5" flex=90>
+                <label>Android package/activity to match</label>
+                <input type="text" ng-model="cue.cueSource" placeholder="com.example.pkg/com.example.Activity">
+            </md-input-container>
+
+            <md-input-container ng-if="cue.cueCode === 18 || cue.cueCode === 19" flex=90>
+                <label>Android package to match</label>
+                <input type="text" ng-model="cue.cueSource" placeholder="com.example.package">
+            </md-input-container>
+
+            <md-input-container ng-if="cue.cueCode === 28 || cue.cueCode === 29 || cue.cueCode === 30 || cue.cueCode === 31" flex=90>
+                <label>app value to match</label>
+                <input type="text" ng-model="cue.cueSource">
+            </md-input-container>
+
+            <paco-help tip="app-triggers" ng-if="cue.cueCode === 4 || cue.cueCode === 5 || cue.cueCode === 18 || cue.cueCode === 19 " >
         <span>Help: App Triggers</span>
       </paco-help>      
         </div>
 
-	    <div layout="column" ng-if="cue.cueCode === 21 || cue.cueCode === 22 || cue.cueCode === 25 || cue.cueCode === 27"  >      
+        <div layout="column" ng-if="cue.cueCode === 32"  >
+            <md-input-container ng-if="cue.cueCode === 32"  flex=30>
+                <label>IDE Event key to match</label>
+                <input type="text" ng-model="cue.cueKey">
+            </md-input-container>
+            <md-input-container ng-if="cue.cueCode === 32" flex=90>
+                <label>Value for key</label>
+                <input type="text" ng-model="cue.cueSource">
+            </md-input-container>
+        </div>
+
+        <div layout="column" ng-if="cue.cueCode === 21 || cue.cueCode === 22 || cue.cueCode === 25 || cue.cueCode === 27"  >
 	      <md-input-container ng-if="cue.cueCode === 21 || cue.cueCode === 22 || cue.cueCode === 25 || cue.cueCode === 27"  flex=30>
 	        <label>Android View Package Name (Optional)</label>
 	        <input type="text" ng-model="cue.cueSource">
@@ -37,6 +64,7 @@
 	        <label>Android View Content Descriptor Text (Optional)</label>
 	        <input type="text" ng-model="cue.cueAEContentDescription">
 	      </md-input-container>
+
       </div>
     </div>
       

--- a/Paco/src/com/pacoapp/paco/sensors/android/BroadcastTriggerService.java
+++ b/Paco/src/com/pacoapp/paco/sensors/android/BroadcastTriggerService.java
@@ -116,6 +116,8 @@ public class BroadcastTriggerService extends Service {
       }
 
 
+      // Note: This code now diverges from the Desktop Taqo code because that code will also need a cueKey in addition to the
+      // cueSource (sourceIdentifier) for a trigger. This version on Android does not need this cueKey field.
       List<Trio<ExperimentGroup, InterruptTrigger, InterruptCue>> triggersThatMatch = ExperimentHelper.shouldTriggerBy(experiment.getExperimentDAO(),
                                                                                                          triggerEvent,
                                                                                                          sourceIdentifier,

--- a/Shared/src/com/pacoapp/paco/shared/model2/InterruptCue.java
+++ b/Shared/src/com/pacoapp/paco/shared/model2/InterruptCue.java
@@ -30,6 +30,11 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
   public static final int NOTIFICATION_TRAY_SWIPE_DISMISS = 25;
   public static final int NOTIFICATION_TRAY_CANCELLED = 26;
   public static final int NOTIFICATION_CLICKED = 27;
+  public static final int APP_USAGE_DESKTOP = 28;
+  public static final int APP_CLOSED_DESKTOP = 29;
+  public static final int APP_USAGE_SHELL = 30;
+  public static final int APP_CLOSED_SHELL = 31;
+  public static final int IDE_IDEA_USAGE = 32;
 
 
 
@@ -42,7 +47,8 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
                                                 ACCESSIBILITY_EVENT_VIEW_CLICKED,
                                                 NOTIFICATION_CREATED, NOTIFICATION_TRAY_OPENED,
                                                 NOTIFICATION_TRAY_CLEAR_ALL, NOTIFICATION_TRAY_SWIPE_DISMISS,
-                                                NOTIFICATION_TRAY_CANCELLED, NOTIFICATION_CLICKED};
+                                                NOTIFICATION_TRAY_CANCELLED, NOTIFICATION_CLICKED,
+                                                APP_USAGE_DESKTOP, APP_CLOSED_DESKTOP, APP_USAGE_SHELL, APP_CLOSED_SHELL, IDE_IDEA_USAGE};
 
   public static final String[] CUE_EVENT_NAMES = new String[] {"HANGUP (deprecated)", "USER_PRESENT", "Paco Action",
                                                            "App Started", "App Stopped",
@@ -56,14 +62,18 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
                                                            "Notification shade dismiss all notifications",
                                                            "Notification shade dismiss notification",
                                                            "Notification shade closed",
-                                                           "Notification tapped in shade"};
+                                                           "Notification tapped in shade",
+                                                           "App Started on Desktop",
+                                                           "App Stopped on Desktop",
+                                                           "App Started in Shell",
+                                                           "App Stopped in Shell",
+                                                           "Idea-based IDE Usage"};
   public static final Integer VIEW_CLICKED = 1;
 
+  private Long id;
 
-
-
-
-
+  private String cueKey; // for specifying the response key in the Paco Event that will contain the possible <cueSource> value.
+  // This is used by Desktop IDE events presently.
 
   private Integer cueCode;
   private String cueSource; // doubles as package name for view_clicked event type
@@ -71,7 +81,13 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
   private Integer cueAEEventType = VIEW_CLICKED;
   private String cueAEContentDescription;
 
-  private Long id;
+  public String getCueKey() {
+    return cueKey;
+  }
+
+  public void setCueKey(String cueKey) {
+    this.cueKey = cueKey;
+  }
 
   public InterruptCue() {
     super();
@@ -101,6 +117,8 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
       validator.isNonEmptyString(cueSource,
                                            "cuesource must be valid for cuecode: " + CUE_EVENT_NAMES[cueCode - 1]);
     }
+    // TODO add validator for APP_USAGE_DESKTOP, APP_USAGE_SHELL, and IDE_IDEA_USAGE, et. al
+    // TODO add validator for Accessibility Events
   }
 
 
@@ -112,6 +130,7 @@ public class InterruptCue extends ModelBase implements Validatable, java.io.Seri
     this.id = id;
   }
 
+  // cues for accessibility record events on Android
   public String getCueAEClassName() {
     return cueAEClassName;
   }


### PR DESCRIPTION
This adds the cues that can be used to define triggers for desktop events (app used on desktop, in shell and in IDEA-based IDEs).